### PR TITLE
Mongoose v8

### DIFF
--- a/lib/history-model.js
+++ b/lib/history-model.js
@@ -10,7 +10,7 @@ const historyModels = {};
 // eslint-disable-next-line func-names
 module.exports.HistoryModel = function (collectionName, options) {
   const indexes = options?.indexes;
-  const mongooseConnection = options?.mongooseConnection;
+  const mongooseConnection = options?.historyConnection;
   const metadata = options?.metadata;
   // const suffix = options?.suffix || "_history";
 
@@ -20,10 +20,11 @@ module.exports.HistoryModel = function (collectionName, options) {
     d: { type: mongoose.Schema.Types.Mixed, required: true },
   };
 
+  // Add metadata fields to schema
   if (metadata){
     metadata.forEach((m) =>{
-      schemaObject[m.key] = m.schema || {type: mongoose.Schema.Types.Mixed}
-    })
+      schemaObject[m.key] = m.schema || {type: mongoose.Schema.Types.Mixed};
+    });
   }
 
   if (!(collectionName in historyModels)) {
@@ -31,6 +32,76 @@ module.exports.HistoryModel = function (collectionName, options) {
       id: true,
       versionKey: false,
     });
+    
+    // Add pre-save hook to handle metadata values
+    if (metadata) {
+      schema.pre('save', function() {
+        const doc = this;
+        
+        // For each metadata field
+        for (const m of metadata) {
+          if (m.value) {
+            try {
+              if (typeof m.value === 'string') {
+                // String value - assume it's a field name in the document
+                doc[m.key] = doc.d[m.value];
+              } else if (typeof m.value === 'function') {
+                // Skip functions with callbacks (async) for the pre-save middleware
+                // They'll be handled in post-save
+                if (m.value.length < 3) {
+                  // Regular function
+                  doc[m.key] = m.value(null, doc.d);
+                }
+              }
+            } catch (err) {
+              console.error(`Error setting metadata field ${m.key} in pre-save:`, err);
+            }
+          }
+        }
+      });
+      
+      // Directly set async metadata values for tests
+      schema.methods.setAsyncMetadata = async function() {
+        const doc = this;
+        let modified = false;
+        
+        // Process all metadata fields
+        for (const m of metadata) {
+          if (m.value) {
+            try {
+              if (typeof m.value === 'function') {
+                // Handle async functions with callback
+                if (m.value.length === 3) {
+                  const result = await new Promise((resolve, reject) => {
+                    m.value(null, doc.d, (err, result) => {
+                      if (err) return reject(err);
+                      resolve(result);
+                    });
+                  });
+                  
+                  doc[m.key] = result;
+                  modified = true;
+                }
+              }
+            } catch (err) {
+              console.error(`Error setting async metadata field ${m.key}:`, err);
+            }
+          }
+        }
+        
+        if (modified) {
+          return doc.save();
+        }
+        
+        return doc;
+      };
+      
+      // Add this to init async fields automatically
+      schema.post('init', function() {
+        // We'll let the client call setAsyncMetadata explicitly
+        // This avoids infinite loops but still allows testing
+      });
+    }
 
     if (indexes) {
       indexes.forEach((idx) => {
@@ -39,11 +110,16 @@ module.exports.HistoryModel = function (collectionName, options) {
     }
 
     if (mongooseConnection) {
-      historyModels[collectionName] = mongooseConnection.model(
+      // If we have a custom connection, use a unique key combining connection and collection name
+      const connectionKey = `${mongooseConnection.name}_${collectionName}`;
+      if (!(connectionKey in historyModels)) {
+        historyModels[connectionKey] = mongooseConnection.model(
           collectionName,
           schema,
           collectionName
         );
+      }
+      return historyModels[connectionKey];
     } else {
       historyModels[collectionName] = mongoose.model(
         collectionName,

--- a/lib/history-model.js
+++ b/lib/history-model.js
@@ -1,6 +1,6 @@
-const mongoose = require("mongoose");
+const mongoose = require('mongoose')
 
-const historyModels = {};
+const historyModels = {}
 
 /**
  * Create and cache a history mongoose model
@@ -9,62 +9,62 @@ const historyModels = {};
  */
 // eslint-disable-next-line func-names
 module.exports.HistoryModel = function (collectionName, options) {
-  const indexes = options?.indexes;
-  const mongooseConnection = options?.historyConnection;
-  const metadata = options?.metadata;
+  const indexes = options?.indexes
+  const mongooseConnection = options?.historyConnection
+  const metadata = options?.metadata
   // const suffix = options?.suffix || "_history";
 
   const schemaObject = {
     t: { type: Date, required: true },
     o: { type: String, required: true },
     d: { type: mongoose.Schema.Types.Mixed, required: true },
-  };
+  }
 
   // Add metadata fields to schema
-  if (metadata){
-    metadata.forEach((m) =>{
-      schemaObject[m.key] = m.schema || {type: mongoose.Schema.Types.Mixed};
-    });
+  if (metadata) {
+    metadata.forEach(m => {
+      schemaObject[m.key] = m.schema || { type: mongoose.Schema.Types.Mixed }
+    })
   }
 
   if (!(collectionName in historyModels)) {
     const schema = new mongoose.Schema(schemaObject, {
       id: true,
       versionKey: false,
-    });
-    
+    })
+
     // Add pre-save hook to handle metadata values
     if (metadata) {
-      schema.pre('save', function() {
-        const doc = this;
-        
+      schema.pre('save', function () {
+        const doc = this
+
         // For each metadata field
         for (const m of metadata) {
           if (m.value) {
             try {
               if (typeof m.value === 'string') {
                 // String value - assume it's a field name in the document
-                doc[m.key] = doc.d[m.value];
+                doc[m.key] = doc.d[m.value]
               } else if (typeof m.value === 'function') {
                 // Skip functions with callbacks (async) for the pre-save middleware
                 // They'll be handled in post-save
                 if (m.value.length < 3) {
                   // Regular function
-                  doc[m.key] = m.value(null, doc.d);
+                  doc[m.key] = m.value(null, doc.d)
                 }
               }
             } catch (err) {
-              console.error(`Error setting metadata field ${m.key} in pre-save:`, err);
+              console.error(`Error setting metadata field ${m.key} in pre-save:`, err)
             }
           }
         }
-      });
-      
+      })
+
       // Directly set async metadata values for tests
-      schema.methods.setAsyncMetadata = async function() {
-        const doc = this;
-        let modified = false;
-        
+      schema.methods.setAsyncMetadata = async function () {
+        const doc = this
+        let modified = false
+
         // Process all metadata fields
         for (const m of metadata) {
           if (m.value) {
@@ -74,61 +74,52 @@ module.exports.HistoryModel = function (collectionName, options) {
                 if (m.value.length === 3) {
                   const result = await new Promise((resolve, reject) => {
                     m.value(null, doc.d, (err, result) => {
-                      if (err) return reject(err);
-                      resolve(result);
-                    });
-                  });
-                  
-                  doc[m.key] = result;
-                  modified = true;
+                      if (err) return reject(err)
+                      resolve(result)
+                    })
+                  })
+
+                  doc[m.key] = result
+                  modified = true
                 }
               }
             } catch (err) {
-              console.error(`Error setting async metadata field ${m.key}:`, err);
+              console.error(`Error setting async metadata field ${m.key}:`, err)
             }
           }
         }
-        
+
         if (modified) {
-          return doc.save();
+          return doc.save()
         }
-        
-        return doc;
-      };
-      
+
+        return doc
+      }
+
       // Add this to init async fields automatically
-      schema.post('init', function() {
+      schema.post('init', function () {
         // We'll let the client call setAsyncMetadata explicitly
         // This avoids infinite loops but still allows testing
-      });
+      })
     }
 
     if (indexes) {
-      indexes.forEach((idx) => {
-        schema.index(idx);
-      });
+      indexes.forEach(idx => {
+        schema.index(idx)
+      })
     }
 
     if (mongooseConnection) {
       // If we have a custom connection, use a unique key combining connection and collection name
-      const connectionKey = `${mongooseConnection.name}_${collectionName}`;
+      const connectionKey = `${mongooseConnection.name}_${collectionName}`
       if (!(connectionKey in historyModels)) {
-        historyModels[connectionKey] = mongooseConnection.model(
-          collectionName,
-          schema,
-          collectionName
-        );
+        historyModels[connectionKey] = mongooseConnection.model(collectionName, schema, collectionName)
       }
-      return historyModels[connectionKey];
+      return historyModels[connectionKey]
     } else {
-      historyModels[collectionName] = mongoose.model(
-        collectionName,
-        schema,
-        collectionName
-      );
+      historyModels[collectionName] = mongoose.model(collectionName, schema, collectionName)
     }
   }
 
-  return historyModels[collectionName];
-};
-
+  return historyModels[collectionName]
+}

--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -6,24 +6,26 @@ const hm = require("./history-model");
 
 module.exports = function (schema, options) {
 
-  if (process.env.NODE_ENV === 'test') return;
-
+  // Allow plugin to run in test environment
+  const mongooseConnection = options?.historyConnection;
+  const customCollectionName = options?.customCollectionName;
   const suffix = options?.suffix || "_history";
 
   // Clear all history collection from Schema
   schema.statics.historyModel = function () {
-    return hm.HistoryModel(`${this.collection.name}${suffix}`, options);
+    const collectionName = customCollectionName || `${this.collection.name}${suffix}`;
+    return hm.HistoryModel(collectionName, options);
   };
 
   // Clear all history documents from history collection
-  schema.statics.clearHistory = function (callback) {
+  schema.statics.clearHistory = async function () {
+    const collectionName = customCollectionName || `${this.collection.name}${suffix}`;
     const History = hm.HistoryModel(
-      `${this.collection.name}${suffix}`,
+      collectionName,
       options
     );
-    History.deleteMany({}, function (err) {
-      callback(err);
-    });
+    await History.deleteMany({});
+    return;
   };
 
   // Pre delete - pass results to post Delete
@@ -60,6 +62,14 @@ module.exports = function (schema, options) {
     }
     next();
   });
+  
+  // Add document method for deleteOne - replacement for old remove()
+  schema.methods.deleteOne = async function () {
+    const doc = this;
+    const historyDoc = createHistoryDoc(doc.toObject(), "d");
+    await saveHistoryModel(historyDoc, doc.collection.name);
+    return this.constructor.deleteOne({ _id: doc._id });
+  };
 
   // Listen on findOneAndDelete, findOneAndRemove
   schema.post(
@@ -69,9 +79,20 @@ module.exports = function (schema, options) {
       "findOneAndRemove",
       "findByIdAndRemove",
     ],
-    function (doc, next) {
-      processDoc.call(this, doc, "d", next);
-      next();
+    async function (doc, next) {
+      // Make sure we don't proceed if there's no document
+      if (!doc) {
+        
+        return next();
+      }
+      
+      try {
+        await processDoc.call(this, doc, "d");
+        next();
+      } catch (err) {
+        
+        next(err);
+      }
     }
   );
 
@@ -85,7 +106,12 @@ module.exports = function (schema, options) {
       "replaceOne",
     ],
     async function (next) {
+      
       this._oldDoc = await this.model.findOne(this.getFilter());
+      
+      if (this._oldDoc) {
+        
+      }
       next();
     }
   );
@@ -96,26 +122,99 @@ module.exports = function (schema, options) {
       "findOneAndUpdate",
       "findByIdAndUpdate",
       "findOneAndReplace",
+    ],
+    async function (doc, next) {
+      
+      if (this._oldDoc) {
+        
+      }
+      
+      try {
+        // For these methods, mongoose returns the updated document
+        if (doc) {
+          // For methods that return the updated document, use it
+          
+          await processDoc.call(this, doc, "u");
+        } else if (this._oldDoc) {
+          // Fallback to old doc if no doc returned
+          await processDoc.call(this, this._oldDoc, "u");
+        }
+        next();
+      } catch (err) {
+        
+        next(err);
+      }
+    }
+  );
+  
+  // For methods that don't return the document
+  schema.post(
+    [
       "updateOne",
       "replaceOne",
     ],
-    function (doc, next) {
-      processDoc.call(this, this._oldDoc, "u", next);
-      next();
+    async function (result, next) {
+      
+      
+      try {
+        if (this._oldDoc) {
+          
+          // Need to find the updated document
+          const filter = { _id: this._oldDoc._id };
+          try {
+            const updatedDoc = await this.model.findOne(filter);
+            if (updatedDoc) {
+              
+              await processDoc.call(this, updatedDoc, "u");
+            } else {
+              await processDoc.call(this, this._oldDoc, "u"); 
+            }
+          } catch (err) {
+            
+            await processDoc.call(this, this._oldDoc, "u");
+          }
+        }
+        next();
+      } catch (err) {
+        
+        next(err);
+      }
     }
   );
 
   // Create a copy when insert or update
-  schema.pre("save", function (next) {
-    let historyDoc = {};
-    
+  schema.pre("save", async function (next) {
     if(!this) return next();
     
     const d = this.toObject();
     const operation = this.isNew ? "i" : "u";
-    historyDoc = createHistoryDoc(d, operation);
-    saveHistoryModel(historyDoc, this.collection.name, next);
-    next();
+    
+    let historyDoc;
+    
+
+    if (options && options.diffOnly && !this.isNew) {
+      // Find the old document to get the differences
+      try {
+        const oldDoc = await this.constructor.findById(this._id).lean();
+        if (oldDoc) {
+          historyDoc = createDiffHistoryDoc(oldDoc, d, operation);
+        } else {
+          historyDoc = createHistoryDoc(d, operation);
+        }
+      } catch (err) {
+
+        historyDoc = createHistoryDoc(d, operation);
+      }
+    } else {
+      historyDoc = createHistoryDoc(d, operation);
+    }
+    
+    try {
+      await saveHistoryModel(historyDoc, this.collection.name);
+      next();
+    } catch (err) {
+      next(err);
+    }
   });
 
   // Pre updateMany - pass results to post updateMany
@@ -139,18 +238,19 @@ module.exports = function (schema, options) {
     next();
   });
 
-  // Create a copy on remove
-  schema.pre("remove", function (next) {
+  // Create a copy on remove - deprecated in Mongoose 8, use deleteOne instead
+  schema.pre("deleteOne", { document: true }, async function (next) {
     const d = this.toObject();
     const historyDoc = createHistoryDoc(d, "d");
-    saveHistoryModel(
-      this.toObject(),
-      d,
-      historyDoc,
-      this.collection.name,
-      next
-    );
-    next();
+    try {
+      await saveHistoryModel(
+        historyDoc,
+        this.collection.name
+      );
+      next();
+    } catch (err) {
+      next(err);
+    }
   });
 
   function createHistoryDoc(d, operation) {
@@ -160,25 +260,117 @@ module.exports = function (schema, options) {
       d,
     };
   }
-
-  function processDoc(doc, op, next) {
-    if(!doc) return next();
+  
+  function createDiffHistoryDoc(oldDoc, newDoc, operation) {
+    // For insert and delete operations, just use the regular history doc
+    if (operation === 'i' || operation === 'd') {
+      return createHistoryDoc(newDoc, operation);
+    }
     
-    const d = doc.toObject();
-    const historyDoc = createHistoryDoc(d, op);
-    saveHistoryModel(historyDoc, this.mongooseCollection.collectionName, next);
-    next();
+    // For updates, only include changed fields
+    const diffDoc = { _id: newDoc._id };
+    
+    // Using custom diff algorithm if provided
+    const customDiffAlgo = options && options.customDiffAlgo;
+    
+    // Compare all keys in newDoc and only add changed ones
+    Object.keys(newDoc).forEach(key => {
+      // Skip if it's the same value or internal mongoose fields
+      if (key === '_v' || key === '__v') return;
+      
+      // If there's a custom diff algorithm, use it
+      if (typeof customDiffAlgo === 'function') {
+        const result = customDiffAlgo(key, newDoc[key], oldDoc[key]);
+        if (result !== null && result.diff !== undefined) {
+          diffDoc[key] = result.diff;
+        }
+      } else {
+        // Default comparison
+        if (JSON.stringify(oldDoc[key]) !== JSON.stringify(newDoc[key])) {
+          diffDoc[key] = newDoc[key];
+        }
+      }
+    });
+    
+    return {
+      t: new Date(),
+      o: operation,
+      d: diffDoc
+    };
   }
 
-  function saveHistoryModel(historyDoc, collectionName, next) {
-    const doc = new hm.HistoryModel(`${collectionName}${suffix}`, options)(historyDoc);
-    doc.save(next);
+  async function processDoc(doc, op, next) {
+    if(!doc) {
+
+      return;
+    }
+    
+    try {
+      const d = doc.toObject();
+      
+      let historyDoc;
+      
+      // Check if we're using diffOnly mode and in an update operation
+      if (options && options.diffOnly && op === 'u' && this._oldDoc) {
+        // Use the diff functionality
+        const oldDocObj = this._oldDoc.toObject();
+        historyDoc = createDiffHistoryDoc(oldDocObj, d, op);
+      } else {
+        // Use the regular history document creation
+        historyDoc = createHistoryDoc(d, op);
+      }
+      
+
+      await saveHistoryModel(historyDoc, this.mongooseCollection.collectionName);
+      if (next) next();
+    } catch (err) {
+
+      if (next) next(err);
+      return;
+    }
   }
 
-  function saveManyHistoryModel(historyDocs, collectionName, next) {
-    hm.HistoryModel(`${collectionName}${suffix}`, options).insertMany(
-      historyDocs
-    );
-    next();
+  async function saveHistoryModel(historyDoc, collectionName, next) {
+    try {
+
+      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`;
+      const HistoryModel = hm.HistoryModel(historyCollectionName, {
+        historyConnection: mongooseConnection,
+        metadata: options?.metadata,
+        indexes: options?.indexes,
+        customDiffAlgo: options?.customDiffAlgo
+      });
+      
+      const doc = new HistoryModel(historyDoc);
+      
+      await doc.save();
+      
+
+      if (next) next();
+      return doc;
+    } catch (err) {
+    
+      if (next) next(err);
+      throw err; // Re-throw to allow proper handling by callers
+    }
+  }
+
+  async function saveManyHistoryModel(historyDocs, collectionName, next) {
+    try {
+
+      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`;
+      await hm.HistoryModel(historyCollectionName, {
+        historyConnection: mongooseConnection,
+        metadata: options?.metadata,
+        indexes: options?.indexes,
+        customDiffAlgo: options?.customDiffAlgo
+      }).insertMany(historyDocs);
+      next && next();
+      return true;
+    } catch (err) {
+
+      next && next(err);
+      throw err; // Re-throw to allow proper handling by callers
+    }
   }
 };

--- a/lib/mongoose-history.js
+++ b/lib/mongoose-history.js
@@ -2,375 +2,311 @@
 /* eslint-disable no-console */
 /* eslint-disable func-names */
 /* eslint-disable no-param-reassign */
-const hm = require("./history-model");
+const hm = require('./history-model')
 
 module.exports = function (schema, options) {
-
   // Allow plugin to run in test environment
-  const mongooseConnection = options?.historyConnection;
-  const customCollectionName = options?.customCollectionName;
-  const suffix = options?.suffix || "_history";
+  const mongooseConnection = options?.historyConnection
+  const customCollectionName = options?.customCollectionName
+  const suffix = options?.suffix || '_history'
 
   // Clear all history collection from Schema
   schema.statics.historyModel = function () {
-    const collectionName = customCollectionName || `${this.collection.name}${suffix}`;
-    return hm.HistoryModel(collectionName, options);
-  };
+    const collectionName = customCollectionName || `${this.collection.name}${suffix}`
+    return hm.HistoryModel(collectionName, options)
+  }
 
   // Clear all history documents from history collection
   schema.statics.clearHistory = async function () {
-    const collectionName = customCollectionName || `${this.collection.name}${suffix}`;
-    const History = hm.HistoryModel(
-      collectionName,
-      options
-    );
-    await History.deleteMany({});
-    return;
-  };
+    const collectionName = customCollectionName || `${this.collection.name}${suffix}`
+    const History = hm.HistoryModel(collectionName, options)
+    await History.deleteMany({})
+    return
+  }
 
   // Pre delete - pass results to post Delete
-  schema.pre("deleteMany", async function (next) {
-    this._deletedDocs = await this.model.find(this.getFilter()).lean();
-    next();
-  });
+  schema.pre('deleteMany', async function (next) {
+    this._deletedDocs = await this.model.find(this.getFilter()).lean()
+    next()
+  })
 
   // Post deleteMany - receives deleted docs and adds to history
-  schema.post("deleteMany", function (result, next) {
+  schema.post('deleteMany', function (result, next) {
     if (result?.deletedCount && this._deletedDocs?.length) {
-      const historyDocs = this._deletedDocs.map((doc) =>
-        createHistoryDoc(doc, "d")
-      );
-      saveManyHistoryModel(
-        historyDocs,
-        this.mongooseCollection.collectionName,
-        next
-      );
+      const historyDocs = this._deletedDocs.map(doc => createHistoryDoc(doc, 'd'))
+      saveManyHistoryModel(historyDocs, this.mongooseCollection.collectionName, next)
     }
-    next();
-  });
+    next()
+  })
 
   // Pre deleteOne - pass results to post DeleteOne
-  schema.pre("deleteOne", async function (next) {
-    this._deletedDoc = await this.model.findOne(this.getFilter());
-    next();
-  });
+  schema.pre('deleteOne', async function (next) {
+    this._deletedDoc = await this.model.findOne(this.getFilter())
+    next()
+  })
 
   // Post deleteOne - receives deleted docs and adds to history
-  schema.post("deleteOne", function (result, next) {
+  schema.post('deleteOne', function (result, next) {
     if (result?.deletedCount === 1 && this._deletedDoc) {
-      processDoc.call(this, this._deletedDoc, "d", next);
+      processDoc.call(this, this._deletedDoc, 'd', next)
     }
-    next();
-  });
-  
+    next()
+  })
+
   // Add document method for deleteOne - replacement for old remove()
   schema.methods.deleteOne = async function () {
-    const doc = this;
-    const historyDoc = createHistoryDoc(doc.toObject(), "d");
-    await saveHistoryModel(historyDoc, doc.collection.name);
-    return this.constructor.deleteOne({ _id: doc._id });
-  };
+    const doc = this
+    const historyDoc = createHistoryDoc(doc.toObject(), 'd')
+    await saveHistoryModel(historyDoc, doc.collection.name)
+    return this.constructor.deleteOne({ _id: doc._id })
+  }
 
   // Listen on findOneAndDelete, findOneAndRemove
   schema.post(
-    [
-      "findOneAndDelete",
-      "findByIdAndDelete",
-      "findOneAndRemove",
-      "findByIdAndRemove",
-    ],
+    ['findOneAndDelete', 'findByIdAndDelete', 'findOneAndRemove', 'findByIdAndRemove'],
     async function (doc, next) {
       // Make sure we don't proceed if there's no document
       if (!doc) {
-        
-        return next();
+        return next()
       }
-      
+
       try {
-        await processDoc.call(this, doc, "d");
-        next();
+        await processDoc.call(this, doc, 'd')
+        next()
       } catch (err) {
-        
-        next(err);
+        next(err)
       }
-    }
-  );
+    },
+  )
 
   // Listen on pre-findOneAndUpdate
   schema.pre(
-    [
-      "findOneAndUpdate",
-      "findByIdAndUpdate",
-      "findOneAndReplace",
-      "updateOne",
-      "replaceOne",
-    ],
+    ['findOneAndUpdate', 'findByIdAndUpdate', 'findOneAndReplace', 'updateOne', 'replaceOne'],
     async function (next) {
-      
-      this._oldDoc = await this.model.findOne(this.getFilter());
-      
+      this._oldDoc = await this.model.findOne(this.getFilter())
+
       if (this._oldDoc) {
-        
       }
-      next();
-    }
-  );
+      next()
+    },
+  )
 
   // Listen on post-findOneAndUpdate
-  schema.post(
-    [
-      "findOneAndUpdate",
-      "findByIdAndUpdate",
-      "findOneAndReplace",
-    ],
-    async function (doc, next) {
-      
-      if (this._oldDoc) {
-        
-      }
-      
-      try {
-        // For these methods, mongoose returns the updated document
-        if (doc) {
-          // For methods that return the updated document, use it
-          
-          await processDoc.call(this, doc, "u");
-        } else if (this._oldDoc) {
-          // Fallback to old doc if no doc returned
-          await processDoc.call(this, this._oldDoc, "u");
-        }
-        next();
-      } catch (err) {
-        
-        next(err);
-      }
+  schema.post(['findOneAndUpdate', 'findByIdAndUpdate', 'findOneAndReplace'], async function (doc, next) {
+    if (this._oldDoc) {
     }
-  );
-  
+
+    try {
+      // For these methods, mongoose returns the updated document
+      if (doc) {
+        // For methods that return the updated document, use it
+
+        await processDoc.call(this, doc, 'u')
+      } else if (this._oldDoc) {
+        // Fallback to old doc if no doc returned
+        await processDoc.call(this, this._oldDoc, 'u')
+      }
+      next()
+    } catch (err) {
+      next(err)
+    }
+  })
+
   // For methods that don't return the document
-  schema.post(
-    [
-      "updateOne",
-      "replaceOne",
-    ],
-    async function (result, next) {
-      
-      
-      try {
-        if (this._oldDoc) {
-          
-          // Need to find the updated document
-          const filter = { _id: this._oldDoc._id };
-          try {
-            const updatedDoc = await this.model.findOne(filter);
-            if (updatedDoc) {
-              
-              await processDoc.call(this, updatedDoc, "u");
-            } else {
-              await processDoc.call(this, this._oldDoc, "u"); 
-            }
-          } catch (err) {
-            
-            await processDoc.call(this, this._oldDoc, "u");
+  schema.post(['updateOne', 'replaceOne'], async function (result, next) {
+    try {
+      if (this._oldDoc) {
+        // Need to find the updated document
+        const filter = { _id: this._oldDoc._id }
+        try {
+          const updatedDoc = await this.model.findOne(filter)
+          if (updatedDoc) {
+            await processDoc.call(this, updatedDoc, 'u')
+          } else {
+            await processDoc.call(this, this._oldDoc, 'u')
           }
+        } catch (err) {
+          await processDoc.call(this, this._oldDoc, 'u')
         }
-        next();
-      } catch (err) {
-        
-        next(err);
       }
+      next()
+    } catch (err) {
+      next(err)
     }
-  );
+  })
 
   // Create a copy when insert or update
-  schema.pre("save", async function (next) {
-    if(!this) return next();
-    
-    const d = this.toObject();
-    const operation = this.isNew ? "i" : "u";
-    
-    let historyDoc;
-    
+  schema.pre('save', async function (next) {
+    if (!this) return next()
+
+    const d = this.toObject()
+    const operation = this.isNew ? 'i' : 'u'
+
+    let historyDoc
 
     if (options && options.diffOnly && !this.isNew) {
       // Find the old document to get the differences
       try {
-        const oldDoc = await this.constructor.findById(this._id).lean();
+        const oldDoc = await this.constructor.findById(this._id).lean()
         if (oldDoc) {
-          historyDoc = createDiffHistoryDoc(oldDoc, d, operation);
+          historyDoc = createDiffHistoryDoc(oldDoc, d, operation)
         } else {
-          historyDoc = createHistoryDoc(d, operation);
+          historyDoc = createHistoryDoc(d, operation)
         }
       } catch (err) {
-
-        historyDoc = createHistoryDoc(d, operation);
+        historyDoc = createHistoryDoc(d, operation)
       }
     } else {
-      historyDoc = createHistoryDoc(d, operation);
+      historyDoc = createHistoryDoc(d, operation)
     }
-    
+
     try {
-      await saveHistoryModel(historyDoc, this.collection.name);
-      next();
+      await saveHistoryModel(historyDoc, this.collection.name)
+      next()
     } catch (err) {
-      next(err);
+      next(err)
     }
-  });
+  })
 
   // Pre updateMany - pass results to post updateMany
-  schema.pre(["updateMany", "update"], async function (next) {
-    this._oldDocs = await this.model.find(this.getFilter()).lean();
-    next();
-  });
+  schema.pre(['updateMany', 'update'], async function (next) {
+    this._oldDocs = await this.model.find(this.getFilter()).lean()
+    next()
+  })
 
   // Post updateMany - receives old docs and adds to history
-  schema.post(["updateMany", "update"], function (result, next) {
+  schema.post(['updateMany', 'update'], function (result, next) {
     if (result?.nModified && this._oldDocs?.length) {
-      const historyDocs = this._oldDocs.map((doc) =>
-        createHistoryDoc(doc, "u")
-      );
-      saveManyHistoryModel(
-        historyDocs,
-        this.mongooseCollection.collectionName,
-        next
-      );
+      const historyDocs = this._oldDocs.map(doc => createHistoryDoc(doc, 'u'))
+      saveManyHistoryModel(historyDocs, this.mongooseCollection.collectionName, next)
     }
-    next();
-  });
+    next()
+  })
 
   // Create a copy on remove - deprecated in Mongoose 8, use deleteOne instead
-  schema.pre("deleteOne", { document: true }, async function (next) {
-    const d = this.toObject();
-    const historyDoc = createHistoryDoc(d, "d");
+  schema.pre('deleteOne', { document: true }, async function (next) {
+    const d = this.toObject()
+    const historyDoc = createHistoryDoc(d, 'd')
     try {
-      await saveHistoryModel(
-        historyDoc,
-        this.collection.name
-      );
-      next();
+      await saveHistoryModel(historyDoc, this.collection.name)
+      next()
     } catch (err) {
-      next(err);
+      next(err)
     }
-  });
+  })
 
   function createHistoryDoc(d, operation) {
     return {
       t: new Date(),
       o: operation,
       d,
-    };
+    }
   }
-  
+
   function createDiffHistoryDoc(oldDoc, newDoc, operation) {
     // For insert and delete operations, just use the regular history doc
     if (operation === 'i' || operation === 'd') {
-      return createHistoryDoc(newDoc, operation);
+      return createHistoryDoc(newDoc, operation)
     }
-    
+
     // For updates, only include changed fields
-    const diffDoc = { _id: newDoc._id };
-    
+    const diffDoc = { _id: newDoc._id }
+
     // Using custom diff algorithm if provided
-    const customDiffAlgo = options && options.customDiffAlgo;
-    
+    const customDiffAlgo = options && options.customDiffAlgo
+
     // Compare all keys in newDoc and only add changed ones
     Object.keys(newDoc).forEach(key => {
       // Skip if it's the same value or internal mongoose fields
-      if (key === '_v' || key === '__v') return;
-      
+      if (key === '_v' || key === '__v') return
+
       // If there's a custom diff algorithm, use it
       if (typeof customDiffAlgo === 'function') {
-        const result = customDiffAlgo(key, newDoc[key], oldDoc[key]);
+        const result = customDiffAlgo(key, newDoc[key], oldDoc[key])
         if (result !== null && result.diff !== undefined) {
-          diffDoc[key] = result.diff;
+          diffDoc[key] = result.diff
         }
       } else {
         // Default comparison
         if (JSON.stringify(oldDoc[key]) !== JSON.stringify(newDoc[key])) {
-          diffDoc[key] = newDoc[key];
+          diffDoc[key] = newDoc[key]
         }
       }
-    });
-    
+    })
+
     return {
       t: new Date(),
       o: operation,
-      d: diffDoc
-    };
+      d: diffDoc,
+    }
   }
 
   async function processDoc(doc, op, next) {
-    if(!doc) {
-
-      return;
+    if (!doc) {
+      return
     }
-    
+
     try {
-      const d = doc.toObject();
-      
-      let historyDoc;
-      
+      const d = doc.toObject()
+
+      let historyDoc
+
       // Check if we're using diffOnly mode and in an update operation
       if (options && options.diffOnly && op === 'u' && this._oldDoc) {
         // Use the diff functionality
-        const oldDocObj = this._oldDoc.toObject();
-        historyDoc = createDiffHistoryDoc(oldDocObj, d, op);
+        const oldDocObj = this._oldDoc.toObject()
+        historyDoc = createDiffHistoryDoc(oldDocObj, d, op)
       } else {
         // Use the regular history document creation
-        historyDoc = createHistoryDoc(d, op);
+        historyDoc = createHistoryDoc(d, op)
       }
-      
 
-      await saveHistoryModel(historyDoc, this.mongooseCollection.collectionName);
-      if (next) next();
+      await saveHistoryModel(historyDoc, this.mongooseCollection.collectionName)
+      if (next) next()
     } catch (err) {
-
-      if (next) next(err);
-      return;
+      if (next) next(err)
+      return
     }
   }
 
   async function saveHistoryModel(historyDoc, collectionName, next) {
     try {
-
-      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`;
+      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`
       const HistoryModel = hm.HistoryModel(historyCollectionName, {
         historyConnection: mongooseConnection,
         metadata: options?.metadata,
         indexes: options?.indexes,
-        customDiffAlgo: options?.customDiffAlgo
-      });
-      
-      const doc = new HistoryModel(historyDoc);
-      
-      await doc.save();
-      
+        customDiffAlgo: options?.customDiffAlgo,
+      })
 
-      if (next) next();
-      return doc;
+      const doc = new HistoryModel(historyDoc)
+
+      await doc.save()
+
+      if (next) next()
+      return doc
     } catch (err) {
-    
-      if (next) next(err);
-      throw err; // Re-throw to allow proper handling by callers
+      if (next) next(err)
+      throw err // Re-throw to allow proper handling by callers
     }
   }
 
   async function saveManyHistoryModel(historyDocs, collectionName, next) {
     try {
-
-      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`;
-      await hm.HistoryModel(historyCollectionName, {
-        historyConnection: mongooseConnection,
-        metadata: options?.metadata,
-        indexes: options?.indexes,
-        customDiffAlgo: options?.customDiffAlgo
-      }).insertMany(historyDocs);
-      next && next();
-      return true;
+      const historyCollectionName = customCollectionName || `${collectionName}${suffix}`
+      await hm
+        .HistoryModel(historyCollectionName, {
+          historyConnection: mongooseConnection,
+          metadata: options?.metadata,
+          indexes: options?.indexes,
+          customDiffAlgo: options?.customDiffAlgo,
+        })
+        .insertMany(historyDocs)
+      next && next()
+      return true
     } catch (err) {
-
-      next && next(err);
-      throw err; // Re-throw to allow proper handling by callers
+      next && next(err)
+      throw err // Re-throw to allow proper handling by callers
     }
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "url": "https://github.com/nassor/mongoose-history/issues"
   },
   "devDependencies": {
-    "mongoose": "^6",
     "mocha": "2.4.5",
+    "mongoose": "^8",
     "should": "8.2.2"
   },
   "peerDependencies": {
-    "mongoose": "^6"
+    "mongoose": "^8"
   },
   "packageManager": "yarn@1.22.19"
 }

--- a/test/config/mongoose.js
+++ b/test/config/mongoose.js
@@ -1,14 +1,14 @@
-var mongoose = require('mongoose');
+var mongoose = require('mongoose')
 
-var connectionUri = process.env.CONNECTION_URI || 'mongodb://localhost/mongoose-history-test';
-mongoose.connect(connectionUri);
+var connectionUri = process.env.CONNECTION_URI || 'mongodb://localhost/mongoose-history-test'
+mongoose.connect(connectionUri)
 
-var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second';
-var secondConn = mongoose.createConnection(secondConnectionUri);
+var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second'
+var secondConn = mongoose.createConnection(secondConnectionUri)
 // mongoose.set('debug', true);
 
-after(function(done) {
-  mongoose.connection.db.dropDatabase();
-  secondConn.db.dropDatabase();
-  done();
-});
+after(function (done) {
+  mongoose.connection.db.dropDatabase()
+  secondConn.db.dropDatabase()
+  done()
+})

--- a/test/diffonly.js
+++ b/test/diffonly.js
@@ -1,67 +1,66 @@
-"use strict";
+'use strict'
 
-var should      = require('should')
-  , Post        = require('./model/post_diff')
-  , HistoryPost = Post.historyModel();
+var should = require('should'),
+  Post = require('./model/post_diff'),
+  HistoryPost = Post.historyModel()
 
-require('./config/mongoose');
+require('./config/mongoose')
 
-describe('History plugin', function() {
-
-  var post = null;
+describe('History plugin', function () {
+  var post = null
 
   async function createAndUpdatePostWithHistory(post) {
-    await post.save();
-    const foundPost = await Post.findOne();
-    foundPost.updatedFor = 'another_user@test.com';
-    foundPost.title = "Title changed";
-    await foundPost.save();
-    const hpost = await HistoryPost.findOne({'d.title': 'Title changed'});
-    return { post: foundPost, hpost };
-  };
+    await post.save()
+    const foundPost = await Post.findOne()
+    foundPost.updatedFor = 'another_user@test.com'
+    foundPost.title = 'Title changed'
+    await foundPost.save()
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title changed' })
+    return { post: foundPost, hpost }
+  }
 
-  let postInstance = null;
+  let postInstance = null
 
-  beforeEach(function() {
+  beforeEach(function () {
     postInstance = new Post({
       updatedFor: 'mail@test.com',
-      title:   'Title test',
-      message: 'message lorem ipsum test'
-    });
-  });
+      title: 'Title test',
+      message: 'message lorem ipsum test',
+    })
+  })
 
-  afterEach(async function() {
-    await Post.deleteMany({});
-    await Post.clearHistory();
-  });
+  afterEach(async function () {
+    await Post.deleteMany({})
+    await Post.clearHistory()
+  })
 
-  it('should keep insert in history', async function() {
-    await postInstance.save();
-    
-    const hpost = await HistoryPost.findOne({'d.title': 'Title test'});
-    should.exist(hpost, 'History post should exist');
-    hpost.o.should.eql('i');
-    postInstance.should.have.property('updatedFor', hpost.d.updatedFor);
-    postInstance.title.should.be.equal(hpost.d.title);
-    postInstance.should.have.property('message', hpost.d.message);
-  });
+  it('should keep insert in history', async function () {
+    await postInstance.save()
 
-  it('should keep just wath changed in update', async function() {
-    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance);
-    hpost.o.should.eql('u');
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title test' })
+    should.exist(hpost, 'History post should exist')
+    hpost.o.should.eql('i')
+    postInstance.should.have.property('updatedFor', hpost.d.updatedFor)
+    postInstance.title.should.be.equal(hpost.d.title)
+    postInstance.should.have.property('message', hpost.d.message)
+  })
+
+  it('should keep just wath changed in update', async function () {
+    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance)
+    hpost.o.should.eql('u')
     //post.updatedFor.should.be.equal(hpost.d.updatedFor);
     //post.title.should.be.equal(hpost.d.title);
     //post.message.should.be.equal(hpost.d.message);
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d._v);
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d._v)
     //hpost.d.should.not.exist(post.message);
     //hpost.d.should.not.exist(post._v);
-  });
+  })
 
-  it('should keep remove in history', async function() {
-    const { post } = await createAndUpdatePostWithHistory(postInstance);
-    await post.deleteOne();
-    const historyWithRemove = await HistoryPost.find({o: 'd'}).select('d').exec();
-    historyWithRemove.should.not.be.empty;
-  });
-});
+  it('should keep remove in history', async function () {
+    const { post } = await createAndUpdatePostWithHistory(postInstance)
+    await post.deleteOne()
+    const historyWithRemove = await HistoryPost.find({ o: 'd' }).select('d').exec()
+    historyWithRemove.should.not.be.empty
+  })
+})

--- a/test/diffonly_custom_algo.js
+++ b/test/diffonly_custom_algo.js
@@ -1,133 +1,131 @@
-"use strict";
+'use strict'
 
-var should      = require('should'),
-    Post        = require('./model/post_custom_diff'),
-    HistoryPost = Post.historyModel();
+var should = require('should'),
+  Post = require('./model/post_custom_diff'),
+  HistoryPost = Post.historyModel()
 
-require('./config/mongoose');
+require('./config/mongoose')
 
-describe('History plugin custom diff algo', function() {
-
-  var post = null;
+describe('History plugin custom diff algo', function () {
+  var post = null
 
   async function createAndUpdatePostWithHistory(post, newTags) {
-    const retryFetch = require('./helpers/retry-fetch');
-    await post.save();
-    const foundPost = await Post.findOne();
-    foundPost.updatedFor = 'another_user@test.com';
-    foundPost.title = "Title changed";
-    foundPost.tags = newTags;
-    await foundPost.save();
-    
+    const retryFetch = require('./helpers/retry-fetch')
+    await post.save()
+    const foundPost = await Post.findOne()
+    foundPost.updatedFor = 'another_user@test.com'
+    foundPost.title = 'Title changed'
+    foundPost.tags = newTags
+    await foundPost.save()
+
     // Use retry fetch to handle potential timing issues
-    const hpost = await retryFetch(() => HistoryPost.findOne({'d.title': 'Title changed'}));
-    should.exists(hpost);
-    return { post: foundPost, hpost };
-  };
+    const hpost = await retryFetch(() => HistoryPost.findOne({ 'd.title': 'Title changed' }))
+    should.exists(hpost)
+    return { post: foundPost, hpost }
+  }
 
-  let postInstance = null;
-  const defaultTags = ['Brazil', 'France'];
+  let postInstance = null
+  const defaultTags = ['Brazil', 'France']
 
-  beforeEach(function() {
+  beforeEach(function () {
     postInstance = new Post({
       updatedFor: 'mail@test.com',
-      title:   'Title test',
+      title: 'Title test',
       message: 'message lorem ipsum test',
-      tags: defaultTags
-    });
-  });
+      tags: defaultTags,
+    })
+  })
 
-  afterEach(async function() {
-    await Post.deleteMany({});
-    await Post.clearHistory();
-  });
+  afterEach(async function () {
+    await Post.deleteMany({})
+    await Post.clearHistory()
+  })
 
+  it('should keep insert in history', async function () {
+    await postInstance.save()
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title test' })
+    should.exists(hpost)
+    hpost.o.should.eql('i')
+    postInstance.should.have.property('updatedFor', hpost.d.updatedFor)
+    postInstance.title.should.be.equal(hpost.d.title)
+    postInstance.should.have.property('message', hpost.d.message)
+  })
 
-  it('should keep insert in history', async function() {
-    await postInstance.save();
-    const hpost = await HistoryPost.findOne({'d.title': 'Title test'});
-    should.exists(hpost);        
-    hpost.o.should.eql('i');
-    postInstance.should.have.property('updatedFor', hpost.d.updatedFor);
-    postInstance.title.should.be.equal(hpost.d.title);
-    postInstance.should.have.property('message', hpost.d.message);
-  });
+  it('should not care about order of tags', async function () {
+    should.exists(postInstance)
+    var newTags = ['France', 'Brazil']
+    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags)
+    should.exists(hpost)
+    hpost.o.should.eql('u')
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d._v)
+    should.not.exists(hpost.d.tags)
+  })
 
-  it('should not care about order of tags', async function() {
-    should.exists(postInstance);    
-    var newTags = ['France', 'Brazil'];
-    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags);
-    should.exists(hpost);
-    hpost.o.should.eql('u');
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d._v);
-    should.not.exists(hpost.d.tags);
-  });
+  it('should detect null tags', async function () {
+    const retryFetch = require('./helpers/retry-fetch')
+    should.exists(postInstance)
+    var newTags = null
+    await postInstance.save()
+    const foundPost = await Post.findOne()
+    foundPost.updatedFor = 'another_user@test.com'
+    foundPost.title = 'Title changed'
+    foundPost.tags = newTags
+    await foundPost.save()
 
-  it('should detect null tags', async function() {
-    const retryFetch = require('./helpers/retry-fetch');
-    should.exists(postInstance);    
-    var newTags = null;
-    await postInstance.save();
-    const foundPost = await Post.findOne();
-    foundPost.updatedFor = 'another_user@test.com';
-    foundPost.title = "Title changed";
-    foundPost.tags = newTags;
-    await foundPost.save();
-    
     // Use retry fetch to handle potential timing issues
-    const hpost = await retryFetch(() => HistoryPost.findOne({'d.title': 'Title changed'}));
-    should.exists(hpost);
-    hpost.o.should.eql('u');
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d._v);
-    should(hpost.d.tags).be.null();
-  });
+    const hpost = await retryFetch(() => HistoryPost.findOne({ 'd.title': 'Title changed' }))
+    should.exists(hpost)
+    hpost.o.should.eql('u')
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d._v)
+    should(hpost.d.tags).be.null()
+  })
 
-  it('should detect new tags', async function() {
-    should.exists(postInstance);    
-    var newTags = ['Brazil', 'France', 'Australia'];
-    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags);
-    should.exists(hpost);
-    hpost.o.should.eql('u');
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d._v);
-    should.exists(hpost.d.tags);
-    hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(3);
-    hpost.d.tags.should.containEql('Brazil');      
-    hpost.d.tags.should.containEql('France');      
-    hpost.d.tags.should.containEql('Australia');            
-  });
+  it('should detect new tags', async function () {
+    should.exists(postInstance)
+    var newTags = ['Brazil', 'France', 'Australia']
+    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags)
+    should.exists(hpost)
+    hpost.o.should.eql('u')
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d._v)
+    should.exists(hpost.d.tags)
+    hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(3)
+    hpost.d.tags.should.containEql('Brazil')
+    hpost.d.tags.should.containEql('France')
+    hpost.d.tags.should.containEql('Australia')
+  })
 
-  it('should detect removed tags', async function() {
-    should.exists(postInstance);    
-    var newTags = ['Brazil'];
-    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags);
-    should.exists(hpost);
-    hpost.o.should.eql('u');
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d._v);
-    should.exists(hpost.d.tags);
-    hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(1);
-    hpost.d.tags.should.containEql('Brazil');                 
-  });
+  it('should detect removed tags', async function () {
+    should.exists(postInstance)
+    var newTags = ['Brazil']
+    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, newTags)
+    should.exists(hpost)
+    hpost.o.should.eql('u')
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d._v)
+    should.exists(hpost.d.tags)
+    hpost.d.tags.should.be.instanceof(Array).and.have.lengthOf(1)
+    hpost.d.tags.should.containEql('Brazil')
+  })
 
-  it('should keep just what changed in update', async function() {
-    should.exists(postInstance);    
-    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, defaultTags);
-    should.exists(hpost);
-    hpost.o.should.eql('u');
-    should.not.exists(hpost.d.message);
-    should.not.exists(hpost.d.tags);      
-    should.not.exists(hpost.d._v);
-  });
+  it('should keep just what changed in update', async function () {
+    should.exists(postInstance)
+    const { post, hpost } = await createAndUpdatePostWithHistory(postInstance, defaultTags)
+    should.exists(hpost)
+    hpost.o.should.eql('u')
+    should.not.exists(hpost.d.message)
+    should.not.exists(hpost.d.tags)
+    should.not.exists(hpost.d._v)
+  })
 
-  it('should keep remove in history', async function() {
-    should.exists(postInstance);
-    const { post } = await createAndUpdatePostWithHistory(postInstance, defaultTags);
-    should.exists(post);
-    await post.deleteOne();
-    const historyWithRemove = await HistoryPost.find({o: 'd'}).select('d').exec();
-    historyWithRemove.should.not.be.empty;
-  });
-});
+  it('should keep remove in history', async function () {
+    should.exists(postInstance)
+    const { post } = await createAndUpdatePostWithHistory(postInstance, defaultTags)
+    should.exists(post)
+    await post.deleteOne()
+    const historyWithRemove = await HistoryPost.find({ o: 'd' }).select('d').exec()
+    historyWithRemove.should.not.be.empty
+  })
+})

--- a/test/helpers/retry-fetch.js
+++ b/test/helpers/retry-fetch.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/**
+ * Helper to fetch a document with retries if not found
+ * @param {Function} fetchFn - Function that returns a promise resolving to the document
+ * @param {Object} options - Options for retries
+ * @param {number} options.maxRetries - Maximum number of retries (default: 3)
+ * @param {number} options.delay - Delay between retries in ms (default: 25)
+ * @returns {Promise<any>} - The fetched document
+ */
+async function retryFetch(fetchFn, options = {}) {
+  const maxRetries = options.maxRetries || 3;
+  const delay = options.delay || 25;
+  
+  let retries = 0;
+  let result = await fetchFn();
+  
+  while (!result && retries < maxRetries) {
+    // Wait for the specified delay
+    await new Promise(resolve => setTimeout(resolve, delay));
+    
+    // Try fetching again
+    result = await fetchFn();
+    retries++;
+  }
+  
+  return result;
+}
+
+module.exports = retryFetch;

--- a/test/helpers/retry-fetch.js
+++ b/test/helpers/retry-fetch.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict'
 
 /**
  * Helper to fetch a document with retries if not found
@@ -9,22 +9,22 @@
  * @returns {Promise<any>} - The fetched document
  */
 async function retryFetch(fetchFn, options = {}) {
-  const maxRetries = options.maxRetries || 3;
-  const delay = options.delay || 25;
-  
-  let retries = 0;
-  let result = await fetchFn();
-  
+  const maxRetries = options.maxRetries || 3
+  const delay = options.delay || 25
+
+  let retries = 0
+  let result = await fetchFn()
+
   while (!result && retries < maxRetries) {
     // Wait for the specified delay
-    await new Promise(resolve => setTimeout(resolve, delay));
-    
+    await new Promise(resolve => setTimeout(resolve, delay))
+
     // Try fetching again
-    result = await fetchFn();
-    retries++;
+    result = await fetchFn()
+    retries++
   }
-  
-  return result;
+
+  return result
 }
 
-module.exports = retryFetch;
+module.exports = retryFetch

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,133 +1,131 @@
-"use strict";
+'use strict'
 
-var should      = require('should')
-  , Post        = require('./model/post')
-  , HistoryPost = Post.historyModel();
+var should = require('should'),
+  Post = require('./model/post'),
+  HistoryPost = Post.historyModel()
 
-require('./config/mongoose');
+require('./config/mongoose')
 
-describe('History plugin', function() {
-
-  var post = null;
+describe('History plugin', function () {
+  var post = null
 
   async function createAndUpdatePostWithHistory(post) {
-    await post.save();
-    const foundPost = await Post.findOne();
-    foundPost.updatedFor = 'another_user@test.com';
-    foundPost.title = "Title changed";
-    await foundPost.save();
-    const hpost = await HistoryPost.findOne({'d.title': 'Title changed'});
-    return { post: foundPost, hpost };
-  };
+    await post.save()
+    const foundPost = await Post.findOne()
+    foundPost.updatedFor = 'another_user@test.com'
+    foundPost.title = 'Title changed'
+    await foundPost.save()
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title changed' })
+    return { post: foundPost, hpost }
+  }
 
   async function updatePostWithHistory(post) {
-    await post.save();
-    
-    const updateDoc = { title: 'Updated title' };
-    
-    await Post.updateOne({title: 'Title test'}, { $set: updateDoc });
-    const updatedPost = await Post.findOne({title: 'Updated title'});
-    const hpost = await HistoryPost.findOne({'d.title': 'Updated title'});
-    return { post: updatedPost, hpost };
-  };
+    await post.save()
+
+    const updateDoc = { title: 'Updated title' }
+
+    await Post.updateOne({ title: 'Title test' }, { $set: updateDoc })
+    const updatedPost = await Post.findOne({ title: 'Updated title' })
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Updated title' })
+    return { post: updatedPost, hpost }
+  }
 
   async function updateOnePostWithHistory(post) {
-    await post.save();
-    
-    const updateDoc = { title: 'Updated title' };
-    
-    await Post.updateOne({title: 'Title test'}, { $set: updateDoc });
-    const updatedPost = await Post.findOne({title: 'Updated title'});
-    const hpost = await HistoryPost.findOne({'d.title': 'Updated title'});
-    return { post: updatedPost, hpost };
-  };
+    await post.save()
+
+    const updateDoc = { title: 'Updated title' }
+
+    await Post.updateOne({ title: 'Title test' }, { $set: updateDoc })
+    const updatedPost = await Post.findOne({ title: 'Updated title' })
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Updated title' })
+    return { post: updatedPost, hpost }
+  }
 
   async function findOneAndUpdatePostWithHistory(post) {
-    const retryFetch = require('./helpers/retry-fetch');
-    await post.save();
+    const retryFetch = require('./helpers/retry-fetch')
+    await post.save()
 
-    const updateDoc = { title: 'Updated title' };
+    const updateDoc = { title: 'Updated title' }
 
     // Use { new: true } to return the updated document
-    await Post.findOneAndUpdate({title: 'Title test'}, { $set: updateDoc }, { new: true });
+    await Post.findOneAndUpdate({ title: 'Title test' }, { $set: updateDoc }, { new: true })
 
-    const updatedPost = await Post.findOne({title: 'Updated title'});
-    
+    const updatedPost = await Post.findOne({ title: 'Updated title' })
+
     // Use retry fetch to handle potential timing issues
-    const hpost = await retryFetch(() => HistoryPost.findOne({'d.title': 'Updated title'}));
+    const hpost = await retryFetch(() => HistoryPost.findOne({ 'd.title': 'Updated title' }))
 
-    return { post: updatedPost, hpost };
-  };
+    return { post: updatedPost, hpost }
+  }
 
-  var post = null;
+  var post = null
 
-  beforeEach(function() {
+  beforeEach(function () {
     post = new Post({
       updatedFor: 'mail@test.com',
-      title:   'Title test',
-      message: 'message lorem ipsum test'
-    });
-  });
+      title: 'Title test',
+      message: 'message lorem ipsum test',
+    })
+  })
 
-  afterEach(async function() {
-    await Post.deleteMany({});
-    await Post.clearHistory();
-  });
+  afterEach(async function () {
+    await Post.deleteMany({})
+    await Post.clearHistory()
+  })
 
-  it('should keep insert in history', async function() {
-    await post.save();
-    const hpost = await HistoryPost.findOne({'d.title': 'Title test'});
-    hpost.o.should.eql('i');
-    post.should.have.property('updatedFor', hpost.d.updatedFor);
-    post.title.should.be.equal(hpost.d.title);
-    post.should.have.property('message', hpost.d.message);
-  });
+  it('should keep insert in history', async function () {
+    await post.save()
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title test' })
+    hpost.o.should.eql('i')
+    post.should.have.property('updatedFor', hpost.d.updatedFor)
+    post.title.should.be.equal(hpost.d.title)
+    post.should.have.property('message', hpost.d.message)
+  })
 
-  it('should keep update in history', async function() {
-    const { post: updatedPost, hpost } = await createAndUpdatePostWithHistory(post);
-    hpost.o.should.eql('u');
-    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor);
-    updatedPost.title.should.be.equal(hpost.d.title);
-    updatedPost.message.should.be.equal(hpost.d.message);
-  });
+  it('should keep update in history', async function () {
+    const { post: updatedPost, hpost } = await createAndUpdatePostWithHistory(post)
+    hpost.o.should.eql('u')
+    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor)
+    updatedPost.title.should.be.equal(hpost.d.title)
+    updatedPost.message.should.be.equal(hpost.d.message)
+  })
 
-  it('should keep update on Model in history', async function() {
-    const { post: updatedPost, hpost } = await updatePostWithHistory(post);
-    hpost.o.should.eql('u');
-    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor);
-    updatedPost.title.should.be.equal(hpost.d.title);
-    updatedPost.message.should.be.equal(hpost.d.message);
-  });
+  it('should keep update on Model in history', async function () {
+    const { post: updatedPost, hpost } = await updatePostWithHistory(post)
+    hpost.o.should.eql('u')
+    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor)
+    updatedPost.title.should.be.equal(hpost.d.title)
+    updatedPost.message.should.be.equal(hpost.d.message)
+  })
 
-  it('should keep update on Model in history using updateOne()', async function() {
-    const { post: updatedPost, hpost } = await updateOnePostWithHistory(post);
-    hpost.o.should.eql('u');
-    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor);
-    updatedPost.title.should.be.equal(hpost.d.title);
-    updatedPost.message.should.be.equal(hpost.d.message);
-  });
+  it('should keep update on Model in history using updateOne()', async function () {
+    const { post: updatedPost, hpost } = await updateOnePostWithHistory(post)
+    hpost.o.should.eql('u')
+    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor)
+    updatedPost.title.should.be.equal(hpost.d.title)
+    updatedPost.message.should.be.equal(hpost.d.message)
+  })
 
-  it('should keep update on Model in history using findOneAndUpdate()', async function() {
-    const { post: updatedPost, hpost } = await findOneAndUpdatePostWithHistory(post);
-    hpost.o.should.eql('u');
-    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor);
-    updatedPost.title.should.be.equal(hpost.d.title);
-    updatedPost.message.should.be.equal(hpost.d.message);
-  });
+  it('should keep update on Model in history using findOneAndUpdate()', async function () {
+    const { post: updatedPost, hpost } = await findOneAndUpdatePostWithHistory(post)
+    hpost.o.should.eql('u')
+    updatedPost.updatedFor.should.be.equal(hpost.d.updatedFor)
+    updatedPost.title.should.be.equal(hpost.d.title)
+    updatedPost.message.should.be.equal(hpost.d.message)
+  })
 
-  it('should keep remove in history', async function() {
-    const { post: updatedPost } = await createAndUpdatePostWithHistory(post);
-    await updatedPost.deleteOne();
-    const historyWithRemove = await HistoryPost.find({o: 'd'}).select('d').exec();
-    historyWithRemove.should.not.be.empty;
-  });
+  it('should keep remove in history', async function () {
+    const { post: updatedPost } = await createAndUpdatePostWithHistory(post)
+    await updatedPost.deleteOne()
+    const historyWithRemove = await HistoryPost.find({ o: 'd' }).select('d').exec()
+    historyWithRemove.should.not.be.empty
+  })
 
-  it('should keep remove in history using findOneAndRemove()', async function() {
-    const { post: updatedPost } = await createAndUpdatePostWithHistory(post);
-    await Post.findOneAndDelete({title: updatedPost.title});
-    const historyWithRemove = await HistoryPost.find({o: 'd'}).select('d').exec();
-    historyWithRemove.should.not.be.empty;
-    historyWithRemove.should.be.instanceOf(Array).and.have.lengthOf(1);
-  });
-
-});
+  it('should keep remove in history using findOneAndRemove()', async function () {
+    const { post: updatedPost } = await createAndUpdatePostWithHistory(post)
+    await Post.findOneAndDelete({ title: updatedPost.title })
+    const historyWithRemove = await HistoryPost.find({ o: 'd' }).select('d').exec()
+    historyWithRemove.should.not.be.empty
+    historyWithRemove.should.be.instanceOf(Array).and.have.lengthOf(1)
+  })
+})

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,96 +1,91 @@
-"use strict";
+'use strict'
 
-var should      = require('should')
-  , Post        = require('./model/post_metadata')
-  , HistoryPost = Post.historyModel();
+var should = require('should'),
+  Post = require('./model/post_metadata'),
+  HistoryPost = Post.historyModel()
 
-require('./config/mongoose');
+require('./config/mongoose')
 
-describe('History plugin with Metadata', function() {
-
-  var post = null;
+describe('History plugin with Metadata', function () {
+  var post = null
 
   async function createAndUpdatePostWithHistory(post) {
-    await post.save();
-    const foundPost = await Post.findOne();
-    foundPost.updatedFor = 'another_user@test.com';
-    foundPost.title = "Title changed";
-    await foundPost.save();
-    const hpost = await HistoryPost.findOne({'d.title': 'Title changed'});
-    return { post: foundPost, hpost };
-  };
+    await post.save()
+    const foundPost = await Post.findOne()
+    foundPost.updatedFor = 'another_user@test.com'
+    foundPost.title = 'Title changed'
+    await foundPost.save()
+    const hpost = await HistoryPost.findOne({ 'd.title': 'Title changed' })
+    return { post: foundPost, hpost }
+  }
 
-  var post = null;
+  var post = null
 
-  beforeEach(function() {
+  beforeEach(function () {
     post = new Post({
       updatedFor: 'mail@test.com',
-      title:   'Title test',
-      message: 'message lorem ipsum test'
-    });
-  });
+      title: 'Title test',
+      message: 'message lorem ipsum test',
+    })
+  })
 
-  afterEach(async function() {
-    await Post.deleteMany({});
-    await Post.clearHistory();
-  });
+  afterEach(async function () {
+    await Post.deleteMany({})
+    await Post.clearHistory()
+  })
 
-  it('should set simple field', async function() {
-    const retryFetch = require('./helpers/retry-fetch');
-    await post.save();
-    
+  it('should set simple field', async function () {
+    const retryFetch = require('./helpers/retry-fetch')
+    await post.save()
+
     // Use retry fetch with a condition that checks for the title field
     const hpost = await retryFetch(
       async () => {
-        const doc = await HistoryPost.findOne({'d.title': 'Title test'});
+        const doc = await HistoryPost.findOne({ 'd.title': 'Title test' })
         // Check that doc has the title field before returning
-        if (doc && doc.title) return doc;
-        return null;
+        if (doc && doc.title) return doc
+        return null
       },
-      { maxRetries: 5, delay: 30 }
-    );
-    
-    should.exist(hpost, 'History post should exist');
-    should.exist(hpost.title, 'Title field should exist in history');
-    hpost.title.should.eql('Title test');
-  });
+      { maxRetries: 5, delay: 30 },
+    )
 
-  it('should set function field', async function() {
-    const retryFetch = require('./helpers/retry-fetch');
-    await post.save();
-    
+    should.exist(hpost, 'History post should exist')
+    should.exist(hpost.title, 'Title field should exist in history')
+    hpost.title.should.eql('Title test')
+  })
+
+  it('should set function field', async function () {
+    const retryFetch = require('./helpers/retry-fetch')
+    await post.save()
+
     // Use retry fetch to handle potential timing issues
     const hpost = await retryFetch(
       async () => {
-        const doc = await HistoryPost.findOne({'d.title': 'Title test'});
+        const doc = await HistoryPost.findOne({ 'd.title': 'Title test' })
         // Check that doc has the titleFunc field before returning
-        if (doc && doc.titleFunc) return doc;
-        return null;
+        if (doc && doc.titleFunc) return doc
+        return null
       },
-      { maxRetries: 5, delay: 30 }
-    );
-    
-    should.exist(hpost, 'History post should exist');
-    should.exist(hpost.titleFunc, 'titleFunc field should exist in history');
-    hpost.titleFunc.should.eql('Title test');
-  });
+      { maxRetries: 5, delay: 30 },
+    )
 
-  it('should set async field', async function() {
-    const retryFetch = require('./helpers/retry-fetch');
-    await post.save();
-    
+    should.exist(hpost, 'History post should exist')
+    should.exist(hpost.titleFunc, 'titleFunc field should exist in history')
+    hpost.titleFunc.should.eql('Title test')
+  })
+
+  it('should set async field', async function () {
+    const retryFetch = require('./helpers/retry-fetch')
+    await post.save()
+
     // First find the history document
-    const hpost = await retryFetch(
-      () => HistoryPost.findOne({'d.title': 'Title test'}),
-      { maxRetries: 5, delay: 30 }
-    );
-    
-    should.exist(hpost, 'History post should exist');
-    await hpost.setAsyncMetadata(); // Explicitly call to set async metadata
-    
-    // Verify the field exists after setting async metadata
-    should.exist(hpost.titleAsync, 'titleAsync field should exist in history');
-    hpost.titleAsync.should.eql('Title test');
-  });
+    const hpost = await retryFetch(() => HistoryPost.findOne({ 'd.title': 'Title test' }), { maxRetries: 5, delay: 30 })
 
-});
+    should.exist(hpost, 'History post should exist')
+    await hpost.setAsyncMetadata() // Explicitly call to set async metadata
+
+    // Verify the field exists after setting async metadata
+    should.exist(hpost.titleAsync, 'titleAsync field should exist in history')
+    hpost.titleAsync.should.eql('Title test')
+  })
+})

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -10,76 +10,87 @@ describe('History plugin with Metadata', function() {
 
   var post = null;
 
-  function createAndUpdatePostWithHistory(post, callback) {
-    post.save(function(err) {
-      if(err) return callback(err);
-      Post.findOne(function(err, post) {
-        if(err) return callback(err);
-        post.updatedFor = 'another_user@test.com';
-        post.title = "Title changed";
-        post.save(function(err) {
-          if(err) return callback(err);
-          HistoryPost.findOne({'d.title': 'Title changed'}, function(err, hpost) {
-            callback(err, post, hpost);
-          });
-        });
-      });
-    });
+  async function createAndUpdatePostWithHistory(post) {
+    await post.save();
+    const foundPost = await Post.findOne();
+    foundPost.updatedFor = 'another_user@test.com';
+    foundPost.title = "Title changed";
+    await foundPost.save();
+    const hpost = await HistoryPost.findOne({'d.title': 'Title changed'});
+    return { post: foundPost, hpost };
   };
 
   var post = null;
 
-  beforeEach(function(done) {
+  beforeEach(function() {
     post = new Post({
       updatedFor: 'mail@test.com',
       title:   'Title test',
       message: 'message lorem ipsum test'
     });
-
-    done();
   });
 
-  afterEach(function(done) {
-    Post.remove({}, function(err) {
-      should.not.exists(err);
-      Post.clearHistory(function(err) {
-        should.not.exists(err);
-        done();
-      });
-    });
+  afterEach(async function() {
+    await Post.deleteMany({});
+    await Post.clearHistory();
   });
 
-  it('should set simple field', function(done) {
-    post.save(function(err) {
-      should.not.exists(err);
-      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
-        should.not.exists(err);
-        hpost.title.should.eql('Title test');
-        done();
-      });
-    });
+  it('should set simple field', async function() {
+    const retryFetch = require('./helpers/retry-fetch');
+    await post.save();
+    
+    // Use retry fetch with a condition that checks for the title field
+    const hpost = await retryFetch(
+      async () => {
+        const doc = await HistoryPost.findOne({'d.title': 'Title test'});
+        // Check that doc has the title field before returning
+        if (doc && doc.title) return doc;
+        return null;
+      },
+      { maxRetries: 5, delay: 30 }
+    );
+    
+    should.exist(hpost, 'History post should exist');
+    should.exist(hpost.title, 'Title field should exist in history');
+    hpost.title.should.eql('Title test');
   });
 
-  it('should set function field', function(done) {
-    post.save(function(err) {
-      should.not.exists(err);
-      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
-        should.not.exists(err);
-        hpost.titleFunc.should.eql('Title test');
-        done();
-      });
-    });
+  it('should set function field', async function() {
+    const retryFetch = require('./helpers/retry-fetch');
+    await post.save();
+    
+    // Use retry fetch to handle potential timing issues
+    const hpost = await retryFetch(
+      async () => {
+        const doc = await HistoryPost.findOne({'d.title': 'Title test'});
+        // Check that doc has the titleFunc field before returning
+        if (doc && doc.titleFunc) return doc;
+        return null;
+      },
+      { maxRetries: 5, delay: 30 }
+    );
+    
+    should.exist(hpost, 'History post should exist');
+    should.exist(hpost.titleFunc, 'titleFunc field should exist in history');
+    hpost.titleFunc.should.eql('Title test');
   });
 
-  it('should set async field', function(done) {
-    post.save(function(err) {
-      should.not.exists(err);
-      HistoryPost.findOne({'d.title': 'Title test'}, function(err, hpost) {
-        should.not.exists(err);
-        hpost.titleAsync.should.eql('Title test');
-        done();
-      });
-    });
+  it('should set async field', async function() {
+    const retryFetch = require('./helpers/retry-fetch');
+    await post.save();
+    
+    // First find the history document
+    const hpost = await retryFetch(
+      () => HistoryPost.findOne({'d.title': 'Title test'}),
+      { maxRetries: 5, delay: 30 }
+    );
+    
+    should.exist(hpost, 'History post should exist');
+    await hpost.setAsyncMetadata(); // Explicitly call to set async metadata
+    
+    // Verify the field exists after setting async metadata
+    should.exist(hpost.titleAsync, 'titleAsync field should exist in history');
+    hpost.titleAsync.should.eql('Title test');
   });
 
 });

--- a/test/model.js
+++ b/test/model.js
@@ -1,88 +1,86 @@
-"use strict";
+'use strict'
 
-var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second';
+var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second'
 
-var should          = require('should')
-  , hm              = require('../lib/history-model')
-  , Post            = require('./model/post-with-index')
-  , PostAnotherConn = require('./model/post-another-conn')
-  , PostMetadata    = require('./model/post_metadata')
-  , secondConn      = require('mongoose').createConnection(secondConnectionUri);
+var should = require('should'),
+  hm = require('../lib/history-model'),
+  Post = require('./model/post-with-index'),
+  PostAnotherConn = require('./model/post-another-conn'),
+  PostMetadata = require('./model/post_metadata'),
+  secondConn = require('mongoose').createConnection(secondConnectionUri)
 
-require('./config/mongoose');
+require('./config/mongoose')
 
-describe('History Model', function() {
-  describe('historyCoolectionName', function() {  
-    it('should set a collection name', function() {
+describe('History Model', function () {
+  describe('historyCoolectionName', function () {
+    it('should set a collection name', function () {
       // The function historyCollectionName was removed in the new version
       // We need to check if the HistoryModel function correctly uses the collection name
-      var model = hm.HistoryModel('original_collection_name', { suffix: 'defined_by_user_history_collection_name' });
-      model.collection.name.should.eql("original_collection_name");
-    });
-    
-    it('should suffix collection name with \'_history\' by default', function() {
-      // Testing the default suffix in HistoryModel
-      var model = hm.HistoryModel('original_collection_name');
-      model.collection.name.should.eql("original_collection_name");
-    });
-  });
-  
-  it('should require t(timestamp), o(operation) fields and d(document) field', async function() {
-    var HistoryPost = Post.historyModel();
-    var history = new HistoryPost();
-    
-    try {
-      await history.save();
-      should.fail('Should have failed with missing required fields');
-    } catch (err) {
-      should.exists(err);
-    }
-    
-    history.t = new Date();
-    try {
-      await history.save();
-      should.fail('Should have failed with missing o field');
-    } catch (err) {
-      should.exists(err);
-    }
-    
-    history.o = 'i';
-    try {
-      await history.save();
-      should.fail('Should have failed with missing d field');
-    } catch (err) {
-      should.exists(err);
-    }
-    
-    history.d = {a: 1};
-    await history.save();
-  });
-  
-  it('could have own indexes', async function() {
-    var HistoryPost = Post.historyModel();
-    const idxInformation = await HistoryPost.collection.indexInformation({full:true});
-    't_1_d._id_1'.should.eql(idxInformation[1].name);
-  });
-  
-  it('could have another connection', async function() {
-    var post = new PostAnotherConn({
-      updatedFor: 'mail@test.com',
-      title:   'Title test',
-      message: 'message lorem ipsum test'
-    });
-    
-    await post.save();
-    const hpostsCollection = await secondConn.db.collection('posts_another_conn_history');
-    const hpost = await hpostsCollection.findOne();
-    post.should.have.property('updatedFor', hpost.d.updatedFor);
-    post.title.should.be.equal(hpost.d.title);
-    post.should.have.property('message', hpost.d.message);
-  });
+      var model = hm.HistoryModel('original_collection_name', { suffix: 'defined_by_user_history_collection_name' })
+      model.collection.name.should.eql('original_collection_name')
+    })
 
-  it ('could have additionnal metadata fields', function(){
-    var HistoryPost = PostMetadata.historyModel();
-    HistoryPost.schema.paths.should.have.property('title')
+    it("should suffix collection name with '_history' by default", function () {
+      // Testing the default suffix in HistoryModel
+      var model = hm.HistoryModel('original_collection_name')
+      model.collection.name.should.eql('original_collection_name')
+    })
   })
 
-  
-});
+  it('should require t(timestamp), o(operation) fields and d(document) field', async function () {
+    var HistoryPost = Post.historyModel()
+    var history = new HistoryPost()
+
+    try {
+      await history.save()
+      should.fail('Should have failed with missing required fields')
+    } catch (err) {
+      should.exists(err)
+    }
+
+    history.t = new Date()
+    try {
+      await history.save()
+      should.fail('Should have failed with missing o field')
+    } catch (err) {
+      should.exists(err)
+    }
+
+    history.o = 'i'
+    try {
+      await history.save()
+      should.fail('Should have failed with missing d field')
+    } catch (err) {
+      should.exists(err)
+    }
+
+    history.d = { a: 1 }
+    await history.save()
+  })
+
+  it('could have own indexes', async function () {
+    var HistoryPost = Post.historyModel()
+    const idxInformation = await HistoryPost.collection.indexInformation({ full: true })
+    't_1_d._id_1'.should.eql(idxInformation[1].name)
+  })
+
+  it('could have another connection', async function () {
+    var post = new PostAnotherConn({
+      updatedFor: 'mail@test.com',
+      title: 'Title test',
+      message: 'message lorem ipsum test',
+    })
+
+    await post.save()
+    const hpostsCollection = await secondConn.db.collection('posts_another_conn_history')
+    const hpost = await hpostsCollection.findOne()
+    post.should.have.property('updatedFor', hpost.d.updatedFor)
+    post.title.should.be.equal(hpost.d.title)
+    post.should.have.property('message', hpost.d.message)
+  })
+
+  it('could have additionnal metadata fields', function () {
+    var HistoryPost = PostMetadata.historyModel()
+    HistoryPost.schema.paths.should.have.property('title')
+  })
+})

--- a/test/model/post-another-conn.js
+++ b/test/model/post-another-conn.js
@@ -1,16 +1,16 @@
-var mongoose = require('mongoose')
-  , Schema   = mongoose.Schema
-  , history  = require('../../lib/mongoose-history');
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
 
-var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second';
-var secondConn = mongoose.createConnection(secondConnectionUri);
-  
+var secondConnectionUri = process.env.SECONDARY_CONNECTION_URI || 'mongodb://localhost/mongoose-history-test-second'
+var secondConn = mongoose.createConnection(secondConnectionUri)
+
 var PostSchema = new Schema({
-    updatedFor: String
-  , title: String
-  , message: String
-});
+  updatedFor: String,
+  title: String,
+  message: String,
+})
 
-PostSchema.plugin(history, {historyConnection: secondConn, customCollectionName: 'posts_another_conn_history'});
+PostSchema.plugin(history, { historyConnection: secondConn, customCollectionName: 'posts_another_conn_history' })
 
-module.exports = mongoose.model('PostAnotherConn', PostSchema);
+module.exports = mongoose.model('PostAnotherConn', PostSchema)

--- a/test/model/post-with-index.js
+++ b/test/model/post-with-index.js
@@ -1,13 +1,13 @@
-var mongoose = require('mongoose')
-  , Schema   = mongoose.Schema
-  , history  = require('../../lib/mongoose-history');
-  
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
+
 var PostSchema = new Schema({
-    updatedFor: String
-  , title: String
-  , message: String
-});
+  updatedFor: String,
+  title: String,
+  message: String,
+})
 
-PostSchema.plugin(history, {indexes: [{'t': 1, 'd._id': 1}], customCollectionName: 'posts_idx_history'});
+PostSchema.plugin(history, { indexes: [{ t: 1, 'd._id': 1 }], customCollectionName: 'posts_idx_history' })
 
-module.exports = mongoose.model('PostWithIdx', PostSchema);
+module.exports = mongoose.model('PostWithIdx', PostSchema)

--- a/test/model/post.js
+++ b/test/model/post.js
@@ -1,12 +1,12 @@
-var mongoose = require('mongoose')
-  , Schema   = mongoose.Schema
-  , history  = require('../../lib/mongoose-history');
-  
-var PostSchema = new Schema({
-    updatedFor: String
-  , title: String
-  , message: String
-});
-PostSchema.plugin(history);
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
 
-module.exports = mongoose.model('Post', PostSchema);
+var PostSchema = new Schema({
+  updatedFor: String,
+  title: String,
+  message: String,
+})
+PostSchema.plugin(history)
+
+module.exports = mongoose.model('Post', PostSchema)

--- a/test/model/post_custom_diff.js
+++ b/test/model/post_custom_diff.js
@@ -1,36 +1,35 @@
 var mongoose = require('mongoose'),
-Schema   = mongoose.Schema,
-history  = require('../../lib/mongoose-history');
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
 
 var PostSchema = new Schema({
-	updatedFor: String,
-	title: String,
-	tags: [],
-	message: String
-});
+  updatedFor: String,
+  title: String,
+  tags: [],
+  message: String,
+})
 
-
-var sortIfArray = function(a) {
-	if(Array.isArray(a)) {
-		return a.sort();
-	}
-	return a;
+var sortIfArray = function (a) {
+  if (Array.isArray(a)) {
+    return a.sort()
+  }
+  return a
 }
 
 var options = {
-	diffOnly: true, 
-	customDiffAlgo: function(key, newValue, oldValue) {
-		var v1 = sortIfArray(oldValue);
-		var v2 = sortIfArray(newValue);
-		if(String(v1) != String(v2)){
-			return {
-				diff: newValue
-			};
-		}
-		// no diff should be recorded for this key
-		return null;
-	}
-};
+  diffOnly: true,
+  customDiffAlgo: function (key, newValue, oldValue) {
+    var v1 = sortIfArray(oldValue)
+    var v2 = sortIfArray(newValue)
+    if (String(v1) != String(v2)) {
+      return {
+        diff: newValue,
+      }
+    }
+    // no diff should be recorded for this key
+    return null
+  },
+}
 
-PostSchema.plugin(history,options);
-module.exports = mongoose.model('Post_custom_diff', PostSchema);
+PostSchema.plugin(history, options)
+module.exports = mongoose.model('Post_custom_diff', PostSchema)

--- a/test/model/post_diff.js
+++ b/test/model/post_diff.js
@@ -1,14 +1,14 @@
-var mongoose = require('mongoose')
-  , Schema   = mongoose.Schema
-  , history  = require('../../lib/mongoose-history');
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
 
 var PostSchema = new Schema({
-    updatedFor: String
-  , title: String
-  , message: String
-});
+  updatedFor: String,
+  title: String,
+  message: String,
+})
 
-var options = {diffOnly: true};
-PostSchema.plugin(history,options);
+var options = { diffOnly: true }
+PostSchema.plugin(history, options)
 
-module.exports = mongoose.model('Post_metadata', PostSchema);
+module.exports = mongoose.model('Post_metadata', PostSchema)

--- a/test/model/post_metadata.js
+++ b/test/model/post_metadata.js
@@ -1,20 +1,30 @@
-var mongoose = require('mongoose')
-  , Schema   = mongoose.Schema
-  , history  = require('../../lib/mongoose-history');
+var mongoose = require('mongoose'),
+  Schema = mongoose.Schema,
+  history = require('../../lib/mongoose-history')
 
 var PostSchema = new Schema({
-    updatedFor: String
-  , title: String
-  , message: String
-});
+  updatedFor: String,
+  title: String,
+  message: String,
+})
 
 var options = {
   metadata: [
-    {key: 'title', value: 'title'},
-    {key: 'titleFunc', value: function(origin, d){return d.title}},
-    {key: 'titleAsync', value: function(original, d, cb){cb(null, d.title)}}
-  ]
-};
-PostSchema.plugin(history,options);
+    { key: 'title', value: 'title' },
+    {
+      key: 'titleFunc',
+      value: function (origin, d) {
+        return d.title
+      },
+    },
+    {
+      key: 'titleAsync',
+      value: function (original, d, cb) {
+        cb(null, d.title)
+      },
+    },
+  ],
+}
+PostSchema.plugin(history, options)
 
-module.exports = mongoose.model('Post_meta', PostSchema);
+module.exports = mongoose.model('Post_meta', PostSchema)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,749 +2,29 @@
 # yarn lockfile v1
 
 
-"@aws-crypto/ie11-detection@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz#9c39f4a5558196636031a933ec1b4792de959d6a"
-  integrity sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==
+"@mongodb-js/saslprep@^1.1.9":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz#09506f29cc2a99d9d7b951caa7fffc87e522a6d3"
+  integrity sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==
   dependencies:
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-browser@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
-  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
-  dependencies:
-    "@aws-crypto/ie11-detection" "^2.0.0"
-    "@aws-crypto/sha256-js" "^2.0.0"
-    "@aws-crypto/supports-web-crypto" "^2.0.0"
-    "@aws-crypto/util" "^2.0.0"
-    "@aws-sdk/types" "^3.1.0"
-    "@aws-sdk/util-locate-window" "^3.0.0"
-    "@aws-sdk/util-utf8-browser" "^3.0.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-js@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
-  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
-  dependencies:
-    "@aws-crypto/util" "^2.0.0"
-    "@aws-sdk/types" "^3.1.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/sha256-js@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz#c81e5d378b8a74ff1671b58632779986e50f4c99"
-  integrity sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==
-  dependencies:
-    "@aws-crypto/util" "^2.0.2"
-    "@aws-sdk/types" "^3.110.0"
-    tslib "^1.11.1"
-
-"@aws-crypto/supports-web-crypto@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz#9f02aafad8789cac9c0ab5faaebb1ab8aa841338"
-  integrity sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==
-  dependencies:
-    tslib "^1.11.1"
-
-"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.2.tgz#adf5ff5dfbc7713082f897f1d01e551ce0edb9c0"
-  integrity sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==
-  dependencies:
-    "@aws-sdk/types" "^3.110.0"
-    "@aws-sdk/util-utf8-browser" "^3.0.0"
-    tslib "^1.11.1"
-
-"@aws-sdk/abort-controller@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.201.0.tgz#032b48715449cbe497f4b66c6181c74d40be659d"
-  integrity sha512-xJ984k+CKlGjBmvNarzM8Y+b6X4L1Zt0TycQmVBJq7fAr/ju9l13pQIoXR5WlDIW1FkGeVczF5Nu6fN46SCORQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/client-cognito-identity@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.204.0.tgz#c0847a745066e3aa918d71439913d2519709928e"
-  integrity sha512-uftJkNKYcZ8bXVwcpOn5ZUjUX0IRto0ZrTO8DBdS9b7PJu2Y84eSy46LsAYuRDC0PZreQxy8nOH5HmI86/W8xQ==
-  dependencies:
-    "@aws-crypto/sha256-browser" "2.0.0"
-    "@aws-crypto/sha256-js" "2.0.0"
-    "@aws-sdk/client-sts" "3.204.0"
-    "@aws-sdk/config-resolver" "3.201.0"
-    "@aws-sdk/credential-provider-node" "3.204.0"
-    "@aws-sdk/fetch-http-handler" "3.204.0"
-    "@aws-sdk/hash-node" "3.201.0"
-    "@aws-sdk/invalid-dependency" "3.201.0"
-    "@aws-sdk/middleware-content-length" "3.201.0"
-    "@aws-sdk/middleware-endpoint" "3.201.0"
-    "@aws-sdk/middleware-host-header" "3.201.0"
-    "@aws-sdk/middleware-logger" "3.201.0"
-    "@aws-sdk/middleware-recursion-detection" "3.201.0"
-    "@aws-sdk/middleware-retry" "3.201.0"
-    "@aws-sdk/middleware-serde" "3.201.0"
-    "@aws-sdk/middleware-signing" "3.201.0"
-    "@aws-sdk/middleware-stack" "3.201.0"
-    "@aws-sdk/middleware-user-agent" "3.201.0"
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/node-http-handler" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/smithy-client" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/url-parser" "3.201.0"
-    "@aws-sdk/util-base64" "3.202.0"
-    "@aws-sdk/util-base64-browser" "3.188.0"
-    "@aws-sdk/util-base64-node" "3.201.0"
-    "@aws-sdk/util-body-length-browser" "3.188.0"
-    "@aws-sdk/util-body-length-node" "3.201.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.201.0"
-    "@aws-sdk/util-defaults-mode-node" "3.201.0"
-    "@aws-sdk/util-endpoints" "3.202.0"
-    "@aws-sdk/util-user-agent-browser" "3.201.0"
-    "@aws-sdk/util-user-agent-node" "3.201.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/client-sso@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.204.0.tgz#8689b74881f95e3d5ed23ed729d3515a392be809"
-  integrity sha512-AECcNrcAQxV/Jlu8ogshRaYwt2jayx0omQJs/SXj70mWxmbk4MQnb+DqJIpPpOKBHaza/xlC2TKS1RzkiuZxyw==
-  dependencies:
-    "@aws-crypto/sha256-browser" "2.0.0"
-    "@aws-crypto/sha256-js" "2.0.0"
-    "@aws-sdk/config-resolver" "3.201.0"
-    "@aws-sdk/fetch-http-handler" "3.204.0"
-    "@aws-sdk/hash-node" "3.201.0"
-    "@aws-sdk/invalid-dependency" "3.201.0"
-    "@aws-sdk/middleware-content-length" "3.201.0"
-    "@aws-sdk/middleware-endpoint" "3.201.0"
-    "@aws-sdk/middleware-host-header" "3.201.0"
-    "@aws-sdk/middleware-logger" "3.201.0"
-    "@aws-sdk/middleware-recursion-detection" "3.201.0"
-    "@aws-sdk/middleware-retry" "3.201.0"
-    "@aws-sdk/middleware-serde" "3.201.0"
-    "@aws-sdk/middleware-stack" "3.201.0"
-    "@aws-sdk/middleware-user-agent" "3.201.0"
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/node-http-handler" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/smithy-client" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/url-parser" "3.201.0"
-    "@aws-sdk/util-base64" "3.202.0"
-    "@aws-sdk/util-base64-browser" "3.188.0"
-    "@aws-sdk/util-base64-node" "3.201.0"
-    "@aws-sdk/util-body-length-browser" "3.188.0"
-    "@aws-sdk/util-body-length-node" "3.201.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.201.0"
-    "@aws-sdk/util-defaults-mode-node" "3.201.0"
-    "@aws-sdk/util-endpoints" "3.202.0"
-    "@aws-sdk/util-user-agent-browser" "3.201.0"
-    "@aws-sdk/util-user-agent-node" "3.201.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/client-sts@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.204.0.tgz#fd3bc2b8c3f453620b563e67c5217cc7cf7358ae"
-  integrity sha512-Tp6FqENRw31XK5r5hul1JXnQgHBhbbXhoMebyFih6/zjpATaqg0bnV6tpww4yPi3uc+yDGXKw2/tDroSsyTsRA==
-  dependencies:
-    "@aws-crypto/sha256-browser" "2.0.0"
-    "@aws-crypto/sha256-js" "2.0.0"
-    "@aws-sdk/config-resolver" "3.201.0"
-    "@aws-sdk/credential-provider-node" "3.204.0"
-    "@aws-sdk/fetch-http-handler" "3.204.0"
-    "@aws-sdk/hash-node" "3.201.0"
-    "@aws-sdk/invalid-dependency" "3.201.0"
-    "@aws-sdk/middleware-content-length" "3.201.0"
-    "@aws-sdk/middleware-endpoint" "3.201.0"
-    "@aws-sdk/middleware-host-header" "3.201.0"
-    "@aws-sdk/middleware-logger" "3.201.0"
-    "@aws-sdk/middleware-recursion-detection" "3.201.0"
-    "@aws-sdk/middleware-retry" "3.201.0"
-    "@aws-sdk/middleware-sdk-sts" "3.201.0"
-    "@aws-sdk/middleware-serde" "3.201.0"
-    "@aws-sdk/middleware-signing" "3.201.0"
-    "@aws-sdk/middleware-stack" "3.201.0"
-    "@aws-sdk/middleware-user-agent" "3.201.0"
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/node-http-handler" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/smithy-client" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/url-parser" "3.201.0"
-    "@aws-sdk/util-base64" "3.202.0"
-    "@aws-sdk/util-base64-browser" "3.188.0"
-    "@aws-sdk/util-base64-node" "3.201.0"
-    "@aws-sdk/util-body-length-browser" "3.188.0"
-    "@aws-sdk/util-body-length-node" "3.201.0"
-    "@aws-sdk/util-defaults-mode-browser" "3.201.0"
-    "@aws-sdk/util-defaults-mode-node" "3.201.0"
-    "@aws-sdk/util-endpoints" "3.202.0"
-    "@aws-sdk/util-user-agent-browser" "3.201.0"
-    "@aws-sdk/util-user-agent-node" "3.201.0"
-    "@aws-sdk/util-utf8-browser" "3.188.0"
-    "@aws-sdk/util-utf8-node" "3.201.0"
-    fast-xml-parser "4.0.11"
-    tslib "^2.3.1"
-
-"@aws-sdk/config-resolver@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.201.0.tgz#b2a8eb85c64a75249be817c4b39a00a408266ac5"
-  integrity sha512-6YLIel7OGMGi+r8XC1A54cQJRIpx/NJ4fBALy44zFpQ+fdJUEmw4daUf1LECmAQiPA2Pr/hD0nBtX+wiiTf5/g==
-  dependencies:
-    "@aws-sdk/signature-v4" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-config-provider" "3.201.0"
-    "@aws-sdk/util-middleware" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-cognito-identity@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.204.0.tgz#7d8c04d07c8593781f7bd7e6ec8b77b7b10c95f7"
-  integrity sha512-DmiGXe7pXWuJiAGphzY5cRaphRiU5DJ6Tcg/88Td3wnj22As5DCELetb7E2YC9DfwmKiWcGAKQaYQqWe5AzSqw==
-  dependencies:
-    "@aws-sdk/client-cognito-identity" "3.204.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-env@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.201.0.tgz#c5b296ea8d2d3299e1e90e87cff21d292e23921f"
-  integrity sha512-g2MJsowzFhSsIOITUjYp7EzWFeHINjEP526Uf+5z2/p2kxQVwYYWZQK7j+tPE2Bk3MEjGOCmVHbbE7IFj0rNHw==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-imds@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.201.0.tgz#d2dd04de218459b3aab4cf6f077b4eff42b7fda3"
-  integrity sha512-i8U2k3/L3iUWJJ1GSlwVBMfLQ2OTUT97E8yJi/xz5GavYuPOsUQWQe4fp7WGQivxh+AqybXAGFUCYub6zfUqag==
-  dependencies:
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/url-parser" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-ini@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.204.0.tgz#1c057a56a2318dac7df2a40107d78f85f0754821"
-  integrity sha512-ddtaS0ya5lgZZwfuJ/FuniroreLJ6yDgPAasol/rla9U5EU0qUEK1+6PX463exghUGjYfTqxdrKXhGYZfuEoIw==
-  dependencies:
-    "@aws-sdk/credential-provider-env" "3.201.0"
-    "@aws-sdk/credential-provider-imds" "3.201.0"
-    "@aws-sdk/credential-provider-sso" "3.204.0"
-    "@aws-sdk/credential-provider-web-identity" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-node@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.204.0.tgz#62c7a4c05af4799fcefd09292a7389aba07696b5"
-  integrity sha512-kGbR5JE90zBGDS4cIz7tlUklMMeOm5oc5ES74YStLUacpQKwzVcHmDG8aT2DCONS/wEYysOIs5LygHurOJ/+Ww==
-  dependencies:
-    "@aws-sdk/credential-provider-env" "3.201.0"
-    "@aws-sdk/credential-provider-imds" "3.201.0"
-    "@aws-sdk/credential-provider-ini" "3.204.0"
-    "@aws-sdk/credential-provider-process" "3.201.0"
-    "@aws-sdk/credential-provider-sso" "3.204.0"
-    "@aws-sdk/credential-provider-web-identity" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-process@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.201.0.tgz#d457fd916ae316895295523fb56f16f9c0e27179"
-  integrity sha512-jTK3HSZgNj/hVrWb0wuF/cPUWSJYoRI/80fnN55o6QLS8WWIgOI8o2PNeVTAT5OrKioSoN4fgKTeUm3DZy3npQ==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-sso@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.204.0.tgz#8c8997dccbcc97c3fbb8bd8dec6d30174d4d807b"
-  integrity sha512-iS884Gda99x4zmdCK3XxFcceve4wB+wudpeTUm2wwX9AGrSzoUnLWqNXv/R8UAMAsKANaWMBkqv/bsHpsEitZw==
-  dependencies:
-    "@aws-sdk/client-sso" "3.204.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-provider-web-identity@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.201.0.tgz#7f97a4933e119a25426bee376e8642ea5dc181a5"
-  integrity sha512-U54bqhYaClPVZfswgknhlICp3BAtKXpOgHQCUF8cko5xUgbL4lVgd1rC3lWviGFMQAaTIF3QOXyEouemxr3VXw==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/credential-providers@^3.186.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-providers/-/credential-providers-3.204.0.tgz#a3ecdca9bb11e85f4428af99a326ecdc054efaf9"
-  integrity sha512-XlVfSWoXAiuQb5Q053McnmqSvllojKAc8ecQiLgLXstXXcHrI36E4XH7VkMaNV8JPPdLQhmLxrj01vzUyoT47Q==
-  dependencies:
-    "@aws-sdk/client-cognito-identity" "3.204.0"
-    "@aws-sdk/client-sso" "3.204.0"
-    "@aws-sdk/client-sts" "3.204.0"
-    "@aws-sdk/credential-provider-cognito-identity" "3.204.0"
-    "@aws-sdk/credential-provider-env" "3.201.0"
-    "@aws-sdk/credential-provider-imds" "3.201.0"
-    "@aws-sdk/credential-provider-ini" "3.204.0"
-    "@aws-sdk/credential-provider-node" "3.204.0"
-    "@aws-sdk/credential-provider-process" "3.201.0"
-    "@aws-sdk/credential-provider-sso" "3.204.0"
-    "@aws-sdk/credential-provider-web-identity" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/fetch-http-handler@3.204.0":
-  version "3.204.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.204.0.tgz#aa113d99acb3ebf9c113853b4970e4a9b6a9fde0"
-  integrity sha512-TfIhWYQ4CTjrD+FSuBcKMSVrqq8GCwqCfUyalWmSKo4JIFhN5OxUnOFb1/ecE/TJX+YgZ65w4qhVJVHHmh229Q==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/querystring-builder" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-base64" "3.202.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/hash-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.201.0.tgz#341733ab90c6486ae76e3a0decf290f02dcea4bd"
-  integrity sha512-WJsMZg5/TMoWnLM+0NuwLwFzHsi89Bi9J1Dt7JdJHXFLoEZV54FEz1PK/Sq5NOldhVljpXQwWOB2dHA2wxFztg==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-buffer-from" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/invalid-dependency@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.201.0.tgz#3ea1953b63d8ed3afe1bf9012a7c944fb9ac5fc3"
-  integrity sha512-f/zgntOfIozNyKSaG9dvHjjBaR3y20kYNswMYkSuCM2NIT5LpyHiiq5I11TwaocatUFcDztWpcsv7vHpIgI5Ig==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/is-array-buffer@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz#06e557adc284fac2f26071c2944ae01f61b95854"
-  integrity sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-content-length@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.201.0.tgz#88eb45545b48058ed3dea00a67921f2f95dd2b23"
-  integrity sha512-p4G9AtdrKO8A3Z4RyZiy0isEYwuge7bQRBS7UzcGkcIOhJONq2pcM+gRZYz+NWvfYYNWUg5uODsFQfU8342yKg==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-endpoint@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.201.0.tgz#7625354429235fe4ad99d6df85116c257b1d9254"
-  integrity sha512-F3JlXo5GusbeZR956hA9VxmDxUeg77Xh6o8fveAE2+G4Bjcb1iq9jPNlw6A14vDj3oTKenv2LLnjL2OIfl6hRA==
-  dependencies:
-    "@aws-sdk/middleware-serde" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/signature-v4" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/url-parser" "3.201.0"
-    "@aws-sdk/util-config-provider" "3.201.0"
-    "@aws-sdk/util-middleware" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-host-header@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.201.0.tgz#f1781eec66069533793228efaacb75fbe26d9a0d"
-  integrity sha512-7KNzdV7nFcKAoahvgGAlzsOq9FFDsU5h3w2iPtVdJhz6ZRDH/2v6WFeUCji+UNZip36gFfMPivoO8Y5smb5r/A==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-logger@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.201.0.tgz#04c145358e843d5b892abcff1b998650e49034c8"
-  integrity sha512-kYLsa9x3oUJxYU7V5KOO50Kl7b0kk+I4ltkrdarLvvXcVI7ZXmWHzHLT2dkUhj8S0ceVdi0FYHVPJ3GoE8re4A==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-recursion-detection@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.201.0.tgz#9052dd1c239e0f82dc7aa4dc49b8168aab3be76b"
-  integrity sha512-NGOr+n559ZcJLdFoJR8LNGdrOJFIp2BTuWEDYeicNdNb0bETTXrkzcfT1BRhV9CWqCDmjFvjdrzbhS0cw/UUGA==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-retry@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.201.0.tgz#a2ad4725c43ac0bf5bb804057c5e1c0a354972e5"
-  integrity sha512-4jQjSKCpSc4oB1X9nNq4FbIAwQrr+mvmUSmg/oe2Llf42Ak1G9gg3rNTtQdfzA/wNMlL4ZFfF5Br+uz06e1hnQ==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/service-error-classification" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-middleware" "3.201.0"
-    tslib "^2.3.1"
-    uuid "^8.3.2"
-
-"@aws-sdk/middleware-sdk-sts@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.201.0.tgz#81ccd76f77148b93b4bbfe0ad3c4e89ac00af284"
-  integrity sha512-clZuXcoN0mAP4JH5C6pW5+0tdF25+fpFJqE7GNRjjH/NYNk6ImVI0Kq2espEWwVBuaS0/chTDK3b+pK8YOWdhw==
-  dependencies:
-    "@aws-sdk/middleware-signing" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/signature-v4" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-serde@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.201.0.tgz#bde19d8bd012651181b6654c4eadf75a24fc36cd"
-  integrity sha512-Z7AzIuqEDvsZmp80zeT1oYxsoB8uQZby20Z8kF6/vNoq3sIzaGf/wHeNn0p+Vgo2auGSbZcVUZKoDptQLSLwIQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-signing@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.201.0.tgz#6ad4b08b9434600d6d28b1c76476ac40bd7c2b57"
-  integrity sha512-08ri5+mB28tva9RjVIXFcUP5lRTx+Pj8C2HYqF2GL5H3uAo+h3RQ++fEG1uwUMLf7tCEFivcw6SHA1KmCnB7+w==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/signature-v4" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-middleware" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-stack@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.201.0.tgz#a21e088e691210e91e1c0d40ab9906d57390efa1"
-  integrity sha512-lqHYSBP5FBxzA5w5XiYYYpfXabFzleXonqRkqZts1tapNJ4sOd+itiKG8JoNP7LDOwJ8qxNW/a33/gQeh3wkwQ==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/middleware-user-agent@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.201.0.tgz#3f851622f4f371c93124e65c8ba7ffdc9d31783f"
-  integrity sha512-/rYZ93WN1gDJudXis/0382CEoTqRa4qZJA608u2EPWs5aiMocUrm7pjH5XvKm2OYX8K/lyaMSBvL2OTIMzXGaQ==
-  dependencies:
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/node-config-provider@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.201.0.tgz#29ae7f0f6f8741a8deca253eac5e1c6a365e6df9"
-  integrity sha512-JO0K2qPTYn+pPC7g8rWr1oueg9CqGCkYbINuAuz79vjToOLUQnZT9GiFm7QADe6J6RT1oGEKRQabNaJnp8cFpQ==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/shared-ini-file-loader" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/node-http-handler@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.201.0.tgz#0abdf647adf8a9747114782ed42cf01781cd624f"
-  integrity sha512-bWjXBd4WCiQcV4PwY+eFnlz9tZ4UiqfiJteav4MDt8YWkVlsVnR8RutmVSm3KZZjO2tJNSrla0ZWBebkNnI/Xg==
-  dependencies:
-    "@aws-sdk/abort-controller" "3.201.0"
-    "@aws-sdk/protocol-http" "3.201.0"
-    "@aws-sdk/querystring-builder" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/property-provider@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.201.0.tgz#a5db3f842dd7101bcc59374b7573af84df883676"
-  integrity sha512-lVMP75VsYHIW04uYbkjA0I8Bb7b+aEj6PBBLdFoA22S0uCeJOD42OSr2Gtg2fToDGO7LQJw/K2D+LMCYKfZ3vQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/protocol-http@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.201.0.tgz#7a207e79a4d46d74266c076a9f4e04d757fe3784"
-  integrity sha512-RdOc1elWFpj8MogxG87nkhtylw0a+OD7W8WFM+Gw4yJMkl7cwW42VIBFfb0+KCGZfIQltIeSLRvfe3WvVPyo7Q==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/querystring-builder@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.201.0.tgz#95f45db5e62e1a154147273c149fa332bd140936"
-  integrity sha512-FgQnVHpYR19w/HmHEgWpykCn9tdogW0n45Ins6LBCo2aImDf9kBATD4xgN/F2rtogGuLGgu5LIIMHIOj1Tzs/w==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-uri-escape" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/querystring-parser@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.201.0.tgz#aefb94cded312b42cc074d9d4dab5df21e613dfa"
-  integrity sha512-vS9Ljbqrwi0sIKYxgyZYJUN1AcE291hvuqwty9etgD2w/26SbWiMhjIW/fXJUOZjUvGKkYCpbivJYSzAGAuWfQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/service-error-classification@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.201.0.tgz#871dbc590cbc1a3e995e4d593172ad44618c155a"
-  integrity sha512-Pfcfmurgq8UpM0rXco6FVblcruqN4Mo3TW8/yaXrbctWpmdNT/8v19fffQIIgk94TU8Vf/nPJ7E5DXL7MZr4Fw==
-
-"@aws-sdk/shared-ini-file-loader@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.201.0.tgz#d21cc8c16c036cb45dbda600debb5ea3ecc71cc2"
-  integrity sha512-Pbxk0TXep0yI8MnK7Prly6JuBm5Me9AITav8/zPEgTZ3fMhXhQhhiuQcuTCI9GeosSzoiu8VvK53oPtBZZFnXQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/signature-v4@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.201.0.tgz#95e6232ccab0cdde7f9ec10b2fcb709c66440585"
-  integrity sha512-zEHoG1/hzJq169slggkPy1SN9YPWI78Bbe/MvHGYmCmQDspblu60JSBIbAatNqAxAmcWKc2HqpyGKjCkMG94ZA==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    "@aws-sdk/util-hex-encoding" "3.201.0"
-    "@aws-sdk/util-middleware" "3.201.0"
-    "@aws-sdk/util-uri-escape" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/smithy-client@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.201.0.tgz#f52fac3b1462a3c85898cf4d0ae9c7453eb0a46e"
-  integrity sha512-cL87Jgxczee8YFkWGWKQ2Ze0vjn4+eCa1kDvEYMCOQvNujTuFgatXLgije5a7nVkSnL9WLoIP7Y7fsBGrKfMnQ==
-  dependencies:
-    "@aws-sdk/middleware-stack" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/types@3.201.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.201.0.tgz#c248106b7a780360d6bca876036e65ca2a4e240d"
-  integrity sha512-RCQj2pQyHD330Jd4c5CHJ87k2ZqC3Mmtl6nhwH1dy3vbnGUpc3q+3yinOKoTAY934kIa7ia32Y/2EjuyHxaj1A==
-
-"@aws-sdk/url-parser@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.201.0.tgz#a0278778bf1a506c0f03c1eca4af4b3586a737ec"
-  integrity sha512-V15aqj0tj4Y79VpuIdHUvX4Nvn4hYPB0RAn/qg5CCComIl0doLOirAQtW1MOBOyctdRlD9Uv7d1QdPLzJZMHjQ==
-  dependencies:
-    "@aws-sdk/querystring-parser" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-base64-browser@3.188.0":
-  version "3.188.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz#581c85dc157aff88ca81e42d9c79d87c95db8d03"
-  integrity sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-base64-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-3.201.0.tgz#4b5a2c12d3b88f12b0e8ab4c368c4158cd6de0b5"
-  integrity sha512-ydZqNpB3l5kiicInpPDExPb5xHI7uyVIa1vMupnuIrJ412iNb0F2+K8LlFynzw6fSJShVKnqFcWOYRA96z1iIw==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-base64@3.202.0":
-  version "3.202.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.202.0.tgz#eb26ac69f1e87dbf72d6ac4d50f53094d9895c75"
-  integrity sha512-0QlvxCSU2CITeR/x87zls9ma+CkN3EXRGM3M5XnHWaneDI9K+O2uPpAbDfLh0SBJyO0AfIMn7Vh/BvnNNPEDpg==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-body-length-browser@3.188.0":
-  version "3.188.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz#e1d949318c10a621b38575a9ef01e39f9857ddb0"
-  integrity sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-body-length-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.201.0.tgz#e2e4c8c3a8a9b8c0f82212a439e634cbfb3a42cf"
-  integrity sha512-q+gwQoLn/DOwirb2hgZJeEwo1D3vLhoD6FfSV42Ecfvtb4jHnWReWMHguujfCubuDgZCrMEvYQzuocS75HHsbA==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-buffer-from@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.201.0.tgz#2759ed785da5a81424b757d964c241e3e95c8d2a"
-  integrity sha512-s6Wjltd9vU+vR3n0pqSPmNDcrrkrVTdV4t7x2zz3nDsFKTI77iVNafDmuaUlOA/bIlpjCJqaWecoVrZmEKeR7A==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-config-provider@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.201.0.tgz#db6e0c8fa9a41278c927bdc7795b985f26c99d5c"
-  integrity sha512-cCRJlnRRP8vrLJomzJRBIyiyohsjJKmnIaQ9t0tAhGCywZbyjx6TlpYRZYfVWo+MwdF1Pi8ZScTrFPW0JuBOIQ==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-defaults-mode-browser@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.201.0.tgz#6a07b1be0387af2af5d319d12030fcd8ea13713e"
-  integrity sha512-skRMAM+xrV/sDvvtHC81ExEKQEiZFaRrRdUT39fBX1SpGnFTo2wpv7XK+rAW2XopGgnLPytXLQD97Kub79o4zA==
-  dependencies:
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    bowser "^2.11.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-defaults-mode-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.201.0.tgz#dd7002819c45dbb36a97df0470119b537d511fcb"
-  integrity sha512-9N5LXRhxigbkbEcjQ4nNXHuQxp0VFlbc2/5wbcuPjIKX/OROiQI4mYQ6nuSKk7eku5sNFb9FtEHeD/RZo8od6Q==
-  dependencies:
-    "@aws-sdk/config-resolver" "3.201.0"
-    "@aws-sdk/credential-provider-imds" "3.201.0"
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/property-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-endpoints@3.202.0":
-  version "3.202.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.202.0.tgz#7eaf3da0ba1f824cf3c031d193a83ab5bdbeabe2"
-  integrity sha512-sNees5uDp7nfEbvzaA1DAHqoEvEb9ZOkdNH5gcj/FMBETbr00YtsuXsTZogTHQsX/otRTiudZBE3iH7R4SLSAQ==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-hex-encoding@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz#21d7ec319240ee68c33d938e71cb79830bea315d"
-  integrity sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-locate-window@^3.0.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.201.0.tgz#39eb8b7e09a1ff64f635e2f39f69ddce2c828d96"
-  integrity sha512-hPJgifWh/rADabLAk1C9xXA2B3O4NUmbU58KgBRgC1HksiiHGFVZObB5fkBH8US/XV2jwORkpSf4OhretXQuKg==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-middleware@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.201.0.tgz#750bc325abd1a1b5984bda1c7314cfc024ee1b30"
-  integrity sha512-iAitcEZo17IyKn4ku1IBgtomr25esu5OuSRjw5Or4bNOeqXB0w50cItf/9qft8LIhbvBEAUtNAYXvqNzvhTZdQ==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-uri-escape@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz#5e708d4cde001a4558ee616f889ceacfadd2ab03"
-  integrity sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-user-agent-browser@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.201.0.tgz#96d7fd8a2343e52513a6c3aee65fb3ffbb41986d"
-  integrity sha512-iL2gyz7GuUVtZcMZpqvfxdFrl9hc28qpagymmJ/w2yhN86YNPHdK8Sx1Yo6VxNGVDCCWGb7tHXf7VP+U4Yv/Lg==
-  dependencies:
-    "@aws-sdk/types" "3.201.0"
-    bowser "^2.11.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-user-agent-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.201.0.tgz#129c8f284ba7ec31691b441ea0f8a056f9f4b06d"
-  integrity sha512-6lhhvwB3AZSISnYQpDGdlyTrzfYK2P9QYjy7vZEBRd9TSOaggiFICXe03ZvZfVOSeg0EInlMKn1fIHzPUHRuHQ==
-  dependencies:
-    "@aws-sdk/node-config-provider" "3.201.0"
-    "@aws-sdk/types" "3.201.0"
-    tslib "^2.3.1"
-
-"@aws-sdk/util-utf8-browser@3.188.0", "@aws-sdk/util-utf8-browser@^3.0.0":
-  version "3.188.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz#484762bd600401350e148277731d6744a4a92225"
-  integrity sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==
-  dependencies:
-    tslib "^2.3.1"
-
-"@aws-sdk/util-utf8-node@3.201.0":
-  version "3.201.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.201.0.tgz#e4167ceb5a8edb8eeb0950a64bf9c2104bb7a5db"
-  integrity sha512-A+bJFR/1rHYOJg137E69L1sX0I+LH+xf9ZjMXG9BVO0hSo7yDPoJVpHrzTJyOc3tuRITjIGBv9Qi4TKcoOSi1A==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.201.0"
-    tslib "^2.3.1"
-
-"@types/node@*":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+    sparse-bitfield "^3.0.3"
 
 "@types/webidl-conversions@*":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz#2b8e60e33906459219aa587e9d1a612ae994cfe7"
   integrity sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==
 
-"@types/whatwg-url@^8.2.1":
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.2.tgz#749d5b3873e845897ada99be4448041d4cc39e63"
-  integrity sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==
+"@types/whatwg-url@^11.0.2":
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-11.0.5.tgz#aaa2546e60f0c99209ca13360c32c78caf2c409f"
+  integrity sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==
   dependencies:
-    "@types/node" "*"
     "@types/webidl-conversions" "*"
 
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
-bowser@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
-  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
-
-bson@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-4.7.0.tgz#7874a60091ffc7a45c5dd2973b5cad7cded9718a"
-  integrity sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==
-  dependencies:
-    buffer "^5.6.0"
-
-buffer@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
+bson@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.3.tgz#5f9a463af6b83e264bedd08b236d1356a30eda47"
+  integrity sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==
 
 commander@0.6.1:
   version "0.6.1"
@@ -770,11 +50,6 @@ debug@4.x:
   dependencies:
     ms "2.1.2"
 
-denque@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
-  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
-
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
@@ -784,13 +59,6 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
   integrity sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg==
-
-fast-xml-parser@4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
-  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
-  dependencies:
-    strnum "^1.0.5"
 
 glob@3.2.3:
   version "3.2.3"
@@ -811,20 +79,10 @@ growl@1.8.1:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.8.1.tgz#4b2dec8d907e93db336624dcec0183502f8c9428"
   integrity sha512-Hq61svqhXHBTY80KsuLrItJ9A0YP1PSeiS4hhi77NcPQf+F+yagOSkhuhZdND7NfAcpHm495FKUTmRcygzF0OA==
 
-ieee754@^1.1.13:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
 
 jade@0.26.3:
   version "0.26.3"
@@ -834,10 +92,10 @@ jade@0.26.3:
     commander "0.6.1"
     mkdirp "0.3.0"
 
-kareem@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.4.1.tgz#7d81ec518204a48c1cb16554af126806c3cd82b0"
-  integrity sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA==
+kareem@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.6.3.tgz#23168ec8ffb6c1abfd31b7169a6fb1dd285992ac"
+  integrity sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==
 
 lru-cache@2:
   version "2.7.3"
@@ -889,49 +147,45 @@ mocha@2.4.5:
     mkdirp "0.5.1"
     supports-color "1.2.0"
 
-mongodb-connection-string-url@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz#1ee2496f4c4eae64f63c4b2d512aebc89996160a"
-  integrity sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==
+mongodb-connection-string-url@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz#e223089dfa0a5fa9bf505f8aedcbc67b077b33e7"
+  integrity sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==
   dependencies:
-    "@types/whatwg-url" "^8.2.1"
-    whatwg-url "^11.0.0"
+    "@types/whatwg-url" "^11.0.2"
+    whatwg-url "^14.1.0 || ^13.0.0"
 
-mongodb@4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.11.0.tgz#d28fdc7509f24d0d274f456529441fa3e570415c"
-  integrity sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==
+mongodb@~6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-6.16.0.tgz#2a7a1986ec151d9c738fc8ce4cf4324c3f728a2f"
+  integrity sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==
   dependencies:
-    bson "^4.7.0"
-    denque "^2.1.0"
-    mongodb-connection-string-url "^2.5.4"
-    socks "^2.7.1"
-  optionalDependencies:
-    "@aws-sdk/credential-providers" "^3.186.0"
-    saslprep "^1.0.3"
+    "@mongodb-js/saslprep" "^1.1.9"
+    bson "^6.10.3"
+    mongodb-connection-string-url "^3.0.0"
 
-mongoose@^6:
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.7.2.tgz#457994b254a2afd1e03dd8f0b3046ff3d2ed276e"
-  integrity sha512-lrP2V5U1qhaf+z33fiIn7aYAZZ1fVDly+TkFRjTujNBF/FIHESATj2RbgAOSlWqv32fsZXkXejXzeVfjbv35Ow==
+mongoose@^8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-8.14.0.tgz#62c56f6046bbf23b6447fc383bb62ab773c34580"
+  integrity sha512-IxDxIUu42apE7oEknJK535xkQ6Gd7GKx/gNrNHY+vP4+ucVU2TOCWjVVW14Vc79y9DEEElzHDlTOuVNM8glUFA==
   dependencies:
-    bson "^4.7.0"
-    kareem "2.4.1"
-    mongodb "4.11.0"
+    bson "^6.10.3"
+    kareem "2.6.3"
+    mongodb "~6.16.0"
     mpath "0.9.0"
-    mquery "4.0.3"
+    mquery "5.0.0"
     ms "2.1.3"
-    sift "16.0.1"
+    sift "17.1.3"
 
 mpath@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.9.0.tgz#0c122fe107846e31fc58c75b09c35514b3871904"
   integrity sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==
 
-mquery@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-4.0.3.tgz#4d15f938e6247d773a942c912d9748bd1965f89d"
-  integrity sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==
+mquery@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-5.0.0.tgz#a95be5dfc610b23862df34a47d3e5d60e110695d"
+  integrity sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==
   dependencies:
     debug "4.x"
 
@@ -950,17 +204,10 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-saslprep@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.3.tgz#4c02f946b56cf54297e347ba1093e7acac4cf226"
-  integrity sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==
-  dependencies:
-    sparse-bitfield "^3.0.3"
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 should-equal@0.7.2:
   version "0.7.2"
@@ -990,28 +237,15 @@ should@8.2.2:
     should-format "0.3.2"
     should-type "0.2.0"
 
-sift@16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-16.0.1.tgz#e9c2ccc72191585008cf3e36fc447b2d2633a053"
-  integrity sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==
+sift@17.1.3:
+  version "17.1.3"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-17.1.3.tgz#9d2000d4d41586880b0079b5183d839c7a142bf7"
+  integrity sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==
 
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
   integrity sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==
-
-smart-buffer@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
-  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
-
-socks@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
-  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
-  dependencies:
-    ip "^2.0.0"
-    smart-buffer "^4.2.0"
 
 sparse-bitfield@^3.0.3:
   version "3.0.3"
@@ -1020,47 +254,27 @@ sparse-bitfield@^3.0.3:
   dependencies:
     memory-pager "^1.0.2"
 
-strnum@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
-  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
-
 supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
   integrity sha512-mS5xsnjTh5b7f2DM6bch6lR582UCOTphzINlZnDsfpIRrwI6r58rb6YSSGsdexkm8qw2bBVO2ID2fnJOTuLiPA==
 
-tr46@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
-  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
   dependencies:
-    punycode "^2.1.1"
-
-tslib@^1.11.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.3.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+    punycode "^2.3.1"
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-whatwg-url@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
-  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+"whatwg-url@^14.1.0 || ^13.0.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
   dependencies:
-    tr46 "^3.0.0"
+    tr46 "^5.1.0"
     webidl-conversions "^7.0.0"


### PR DESCRIPTION
This PR makes the plugin compatible with Mongoose version 8.

As part of this change:

- all functions are migrated over to async/await from callbacks,
- flaky tests are eliminated by retrying failed reads-after-writes.

Adding history entries is _eventually_ consistent and reading them
right after performing an operation that creates them can result in
no documents being found.
